### PR TITLE
Docs readme and local convenience

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# Roo Code Docs
+
+## Prerequisites
+
+Before running the documentation locally, ensure you have:
+- Ruby installed (2.5.0 or higher recommended)
+- Bundler gem installed (`gem install bundler`)
+
+## Local Development
+
+To build and serve the documentation locally:
+
+```bash
+rake serve
+```
+
+The documentation will be available at http://127.0.0.1:4000

--- a/README.md
+++ b/README.md
@@ -15,3 +15,12 @@ rake serve
 ```
 
 The documentation will be available at http://127.0.0.1:4000
+
+## Contributing
+
+We love community contributions! Here's how to get involved:
+
+1. Check Issues & Requests: See open issues or feature requests.
+2. Fork & branch off main.
+3. Submit a Pull Request once your documentation feature or fix is ready.
+4. Join our Reddit community and Discord for feedback, tips, and announcements.

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,10 @@
+desc 'Build documentation site locally'
+task :serve do
+  Dir.chdir('docs') do
+    sh 'bundle install'
+    sh 'bundle exec jekyll serve'
+  end
+end
+
+# Set default task
+task default: :serve

--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,8 @@
 desc 'Build documentation site locally'
 task :serve do
   Dir.chdir('docs') do
-    sh 'bundle install'
+    # Only run bundle install if Gemfile.lock doesn't exist
+    sh 'bundle install' unless File.exist?('Gemfile.lock')
     sh 'bundle exec jekyll serve'
   end
 end


### PR DESCRIPTION
in order for folks to collaborate on the documentation, it would be useful to have a short 'meta' readme and the ability to preview the documentation locally.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `README.md` and `Rakefile` to facilitate local development and contribution to documentation using Jekyll.
> 
>   - **Documentation**:
>     - Adds `README.md` with instructions for prerequisites, local development, and contribution.
>     - Provides steps to run documentation locally using `rake serve`.
>   - **Local Development**:
>     - Adds `Rakefile` with `serve` task to build and serve documentation using Jekyll.
>     - Sets default task to `serve` in `Rakefile`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code-Docs&utm_source=github&utm_medium=referral)<sup> for d4fd4e871db24acbfb26dc2ba6abbb0bd812efb1. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->