### PR TITLE
Serve docs from the root

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,21 +5,13 @@ This website is built using [Docusaurus](https://docusaurus.io/), a modern stati
 ### Installation
 
 ```
-$ yarn
+$ npm install
 ```
 
 ### Local Development
 
 ```
-$ yarn start
+$ npm start
 ```
 
 This command starts a local development server and opens up a browser window. Most changes are reflected live without having to restart the server.
-
-### Build
-
-```
-$ yarn build
-```
-
-This command generates static content into the `build` directory and can be served using any static contents hosting service.

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -37,6 +37,7 @@ const config: Config = {
       {
         docs: {
           sidebarPath: './sidebars.ts',
+          routeBasePath: '/',
         },
         theme: {
           customCss: './src/css/custom.css',

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,6 +1,0 @@
-import React from 'react';
-import {Redirect} from '@docusaurus/router';
-
-export default function Home() {
-  return <Redirect to="/docs" />;
-}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Serve documentation from the root path and update README to use npm instead of yarn.
> 
>   - **Behavior**:
>     - Serve documentation from the root path by setting `routeBasePath: '/'` in `docusaurus.config.ts`.
>     - Remove redirect from `/` to `/docs` by deleting `index.js`.
>   - **Documentation**:
>     - Update `README.md` to replace `yarn` commands with `npm` commands for installation and local development.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code-Docs&utm_source=github&utm_medium=referral)<sup> for cfa1ac70baebee6f6a75cd18f14be704f8c097fc. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->