### PR TITLE
Add edit links

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -38,6 +38,7 @@ const config: Config = {
         docs: {
           sidebarPath: './sidebars.ts',
           routeBasePath: '/',
+          editUrl: 'https://github.com/RooVetGit/Roo-Code-Docs/edit/main/',
         },
         theme: {
           customCss: './src/css/custom.css',


### PR DESCRIPTION
I like the idea of adding these links to make it easier for the community to contribute - thoughts? Will show up as a link at the bottom of the content and take you directly into the editor in Github.

![Screenshot 2025-02-11 at 6 06 33 PM](https://github.com/user-attachments/assets/1fe6a99e-6146-48ca-b5de-1b165e1bee0e)

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `editUrl` in `docusaurus.config.ts` to enable edit links for documentation pages.
> 
>   - **Behavior**:
>     - Adds `editUrl` in `docusaurus.config.ts` to enable edit links for documentation pages, allowing users to directly edit content on GitHub.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code-Docs&utm_source=github&utm_medium=referral)<sup> for 95aec3fe02ba0b45c1fb38c3aaaaf851ab8c7fdb. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->