### PR TITLE
Added instructions for configuring Ollama models

### DIFF
--- a/docs/advanced-usage/local-models.md
+++ b/docs/advanced-usage/local-models.md
@@ -78,7 +78,7 @@ Roo Code currently supports two main local model providers:
     *   Select "ollama" as the API Provider.
     *   Enter the Model name from the previous step (e.g., `your_model_name`).
     *   (Optional) You can configure the base URL if you're running Ollama on a different machine. The default is `http://localhost:11434`.
-    *   (Optional) Configure Model context size in Advance settings, so Roo Code knows how to manage its sliding window.
+    *   (Optional) Configure Model context size in Advanced settings, so Roo Code knows how to manage its sliding window.
 
 ## Setting Up LM Studio
 

--- a/docs/advanced-usage/local-models.md
+++ b/docs/advanced-usage/local-models.md
@@ -23,13 +23,18 @@ Roo Code currently supports two main local model providers:
 
 ## Setting Up Ollama
 
-1.  **Download and Install Ollama:**  Download the Ollama installer for your operating system from the [Ollama website](https://ollama.com/). Follow the installation instructions.
+1.  **Download and Install Ollama:**  Download the Ollama installer for your operating system from the [Ollama website](https://ollama.com/). Follow the installation instructions. Make sure Ollama is running
+
+    ```bash
+    ollama serve
+    ```
 
 2.  **Download a Model:**  Ollama supports many different models.  You can find a list of available models on the [Ollama website](https://ollama.com/library).  Some recommended models for coding tasks include:
 
     *   `codellama:7b-code` (good starting point, smaller)
     *   `codellama:13b-code` (better quality, larger)
     *   `codellama:34b-code` (even better quality, very large)
+    *   `qwen2.5-coder:32b`
     *   `mistralai/Mistral-7B-Instruct-v0.1` (good general-purpose model)
     *   `deepseek-coder:6.7b-base` (good for coding tasks)
     * `llama3:8b-instruct-q5_1` (good for general tasks)
@@ -37,25 +42,43 @@ Roo Code currently supports two main local model providers:
     To download a model, open your terminal and run:
 
     ```bash
-    ollama run <model_name>
+    ollama pull <model_name>
     ```
 
     For example:
 
     ```bash
-    ollama run codellama:7b-code
+    ollama pull qwen2.5-coder:32b
     ```
-    
-    This will download the model and then run it in your terminal.  You can type `/bye` to exit the model.
-    
-    **Important:** The first time you run a model, Ollama *must* be running. If you run with a model and Ollama is not open, VSCode may hang.
 
-3.  **Configure Roo Code:**
+3. **Configure the Model:** by default, Ollama uses a context window size of 2048 tokens, which is too small for Roo Code requests. You need to have at least 12k to get decent results, ideally - 32k. To configure a model, you actually need to set its parameters and save a copy of it.
+
+   Load the model (we will use `qwen2.5-coder:32b` as an example):
+   
+    ```bash
+    ollama run qwen2.5-coder:32b
+    ```
+
+   Change context size parameter:
+
+    ```bash
+    /set parameter num_ctx 32768
+    ```
+
+    Save the model with a new name:
+
+    ```bash
+    /save your_model_name
+    ```
+      
+
+4.  **Configure Roo Code:**
     *   Open the Roo Code sidebar (🚀 icon).
     *   Click the settings gear icon (⚙️).
     *   Select "ollama" as the API Provider.
-    *   Enter the Model ID (e.g., `codellama:7b-code`).
+    *   Enter the Model name from the previous step (e.g., `your_model_name`).
     *   (Optional) You can configure the base URL if you're running Ollama on a different machine. The default is `http://localhost:11434`.
+    *   (Optional) Configure Model context size in Advance settings, so Roo Code knows how to manage its sliding window.
 
 ## Setting Up LM Studio
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Added detailed instructions for configuring Ollama models, including context size adjustment and updated Roo Code setup.
> 
>   - **Instructions for Ollama**:
>     - Added command `ollama serve` to ensure Ollama is running.
>     - Changed model download command from `ollama run` to `ollama pull`.
>     - Added new model `qwen2.5-coder:32b` to recommended list.
>     - Added steps to configure model context size to 32k tokens using `/set parameter num_ctx 32768` and save with `/save your_model_name`.
>   - **Roo Code Configuration**:
>     - Updated instructions to use the new model name after saving.
>     - Added optional configuration for model context size in advanced settings.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code-Docs&utm_source=github&utm_medium=referral)<sup> for bf21e2b89c139db9fb9a9246c2b5ee81296414eb. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->