### PR TITLE
Use status instead of checks for docusaurus build

### DIFF
--- a/.github/workflows/docusaurus-build.yml
+++ b/.github/workflows/docusaurus-build.yml
@@ -6,18 +6,22 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  statuses: write
+  contents: read
+
 jobs:
   build:
     name: Build Docusaurus Site
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       
     - name: Setup Node.js
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
-        node-version: '18'
+        node-version: '20'
         cache: 'npm'
         
     - name: Install dependencies
@@ -26,23 +30,17 @@ jobs:
     - name: Build site
       run: npm run build
       
-    - name: Update PR Status
+    - name: Update Status
       if: github.event_name == 'pull_request'
-      uses: actions/github-script@v6
+      uses: actions/github-script@v7
       with:
         script: |
-          const { owner, repo, number } = context.issue;
           const { sha } = context.payload.pull_request.head;
           
-          await github.rest.checks.create({
-            owner,
-            repo,
-            name: 'Docusaurus Build',
-            head_sha: sha,
-            status: 'completed',
-            conclusion: 'success',
-            output: {
-              title: 'Build Successful',
-              summary: 'The Docusaurus site built successfully'
-            }
+          await github.rest.repos.createCommitStatus({
+            ...context.repo,
+            sha: sha,
+            state: 'success',
+            description: 'Docusaurus site built successfully',
+            context: 'Docusaurus Build'
           });


### PR DESCRIPTION
Trying this to see if it works from forks
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Switch from checks to commit statuses for Docusaurus build status updates and update action versions in `docusaurus-build.yml`.
> 
>   - **Workflow Changes**:
>     - Switch from using `checks.create` to `repos.createCommitStatus` for updating build status in `docusaurus-build.yml`.
>     - Add `permissions` section to allow writing statuses and reading contents.
>   - **Version Updates**:
>     - Update `actions/checkout` to `v4` and `actions/setup-node` to `v4`.
>     - Update Node.js version from `18` to `20`.
>     - Update `actions/github-script` to `v7`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code-Docs&utm_source=github&utm_medium=referral)<sup> for 18ca554886fbaf4c1dafc64da7aefe64c5c356a1. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->