### PR TITLE
Update using-mcp-in-roo.md

### DIFF
--- a/docs/mcp/using-mcp-in-roo.md
+++ b/docs/mcp/using-mcp-in-roo.md
@@ -172,7 +172,7 @@ Roo Code does not come with any pre-installed MCP servers. You'll need to find a
 * **Ask Roo:** You can ask Roo Code to help you find or even create MCP servers (when "[Enable MCP Server Creation](#enabling-or-disabling-mcp-server-creation)" is enabled)
 * **Build Your Own:** Create custom MCP servers using the SDK to extend Roo Code with your own tools
 
-For full SDK documentation, visit the [MCP GitHub repository](https://github.com/modelcontextprotocol/sdk).
+For full SDK documentation, visit the [MCP GitHub repository](https://github.com/modelcontextprotocol/).
 
 ## Using MCP Tools in Your Workflow
 


### PR DESCRIPTION
Fix MCP Github repository URL which was giving a 404.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix broken URL in `using-mcp-in-roo.md` by updating the MCP GitHub repository link.
> 
>   - **Documentation**:
>     - Fix broken URL in `using-mcp-in-roo.md` by updating the MCP GitHub repository link to `https://github.com/modelcontextprotocol/`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code-Docs&utm_source=github&utm_medium=referral)<sup> for 8174000c6ac2c16632908c8242e4e3cf7fa4f91d. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->