### PR TITLE
Fix image reference in custom modes documentation missing image

### DIFF
--- a/docs/features/custom-modes.md
+++ b/docs/features/custom-modes.md
@@ -73,10 +73,6 @@ Both global and project-specific configurations use the same JSON format. Each c
 
 ### Understanding File Restrictions
 
-<img src="/img/custom-modes/custom-modes-3.png" alt="File restriction pattern examples" width="600" />
-
-*Visual examples of file restriction patterns and which files they match/don't match.*
-
 The `fileRegex` property uses regular expressions to control which files a mode can edit:
 
 * `\\.md$` - Match files ending in ".md"

--- a/docs/features/custom-modes.md
+++ b/docs/features/custom-modes.md
@@ -151,7 +151,7 @@ You can find this setting within the prompt settings by clicking the <Codicon na
 2.  **Create New Mode:** Click the <Codicon name="add" /> button to the right of the Modes heading
 3.  **Fill in Fields:**
 
-        <img src="/img/custom-modes/custom-modes-3.png" alt="Custom mode creation interface in the Prompts tab" width="600" />
+        <img src="/img/custom-modes/custom-modes-2.png" alt="Custom mode creation interface in the Prompts tab" width="600" />
         *The custom mode creation interface showing fields for name, slug, save location, role definition, available tools, and custom instructions.*
 
     * **Name:** Enter a display name for the mode


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fix incorrect image reference in `custom-modes.md` documentation for custom mode creation interface.
> 
>   - **Documentation**:
>     - Fix image reference in `custom-modes.md` from `custom-modes-3.png` to `custom-modes-2.png` for the custom mode creation interface.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code-Docs&utm_source=github&utm_medium=referral)<sup> for 48d5eb87a4df683ed3370be71f373b18689e163f. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->