### PR TITLE
Add Os-specific MCP configuration example to documentation

### DIFF
--- a/docs/features/mcp/using-mcp-in-roo.md
+++ b/docs/features/mcp/using-mcp-in-roo.md
@@ -203,3 +203,51 @@ Common issues and solutions:
 * **Permission Errors:** Ensure proper API keys and credentials are configured in your `mcp_settings.json` (for global settings) or `.roo/mcp.json` (for project settings).
 * **Tool Not Available:** Confirm the server is properly implementing the tool and it's not disabled in settings
 * **Slow Performance:** Try adjusting the network timeout value for the specific MCP server
+
+## Platform-Specific MCP Configuration Examples
+
+### Windows Configuration Example
+
+When setting up MCP servers on Windows, you'll need to use the Windows Command Prompt (`cmd`) to execute commands. Here's an example of configuring a Puppeteer MCP server on Windows:
+
+```json
+{
+  "mcpServers": {
+    "puppeteer": {
+      "command": "cmd",
+      "args": [
+        "/c",
+        "npx",
+        "-y",
+        "@modelcontextprotocol/server-puppeteer"
+      ]
+    }
+  }
+}
+```
+
+This Windows-specific configuration:
+- Uses the `cmd` command to access the Windows Command Prompt
+- Uses `/c` to tell cmd to execute the command and then terminate
+- Uses `npx` to run the package without installing it permanently
+- The `-y` flag automatically answers "yes" to any prompts during installation
+- Runs the `@modelcontextprotocol/server-puppeteer` package which provides browser automation capabilities
+
+:::note
+For macOS or Linux, you would use a different configuration:
+```json
+{
+  "mcpServers": {
+    "puppeteer": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@modelcontextprotocol/server-puppeteer"
+      ]
+    }
+  }
+}
+```
+:::
+
+The same approach can be used for other MCP servers on Windows, adjusting the package name as needed for different server types.


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add platform-specific MCP configuration examples to documentation, including Windows and macOS/Linux setups.
> 
>   - **Documentation**:
>     - Adds platform-specific MCP configuration examples to `using-mcp-in-roo.md`.
>     - Includes a Windows-specific example using `cmd` and `npx` for Puppeteer MCP server.
>     - Provides a macOS/Linux example for comparison, using `npx` directly.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code-Docs&utm_source=github&utm_medium=referral)<sup> for cffa726e6a20489ce327abddaf3599e316abec98. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->