### PR TITLE
Update docs to reflect change to .roorules

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -116,7 +116,7 @@ Yes, you can customize Roo Code in several ways:
 
 *   **Custom Instructions:** Provide general instructions that apply to all modes, or mode-specific instructions.
 *   **Custom Modes:** Create your own modes with tailored prompts and tool permissions.
-*   **`.clinerules` Files:** Create `.clinerules` files in your project to provide additional guidelines.
+*   **`.roorules` Files:** Create `.roorules` files in your project to provide additional guidelines.
 *   **Settings:** Adjust various settings, such as auto-approval, diff editing, and more.
 
 ### Does Roo Code have any auto approval settings?

--- a/docs/features/custom-instructions.md
+++ b/docs/features/custom-instructions.md
@@ -26,7 +26,7 @@ These instructions only apply within your current workspace, allowing you to cus
 
 #### Workspace-Wide Instructions
 
-Workspace-wide instructions can be defined in the Prompts tab or through a `.roorules` file in your workspace root.
+Workspace-wide instructions can be defined in a `.roorules` file in your workspace root.
 
 #### Mode-Specific Instructions
 

--- a/docs/features/custom-instructions.md
+++ b/docs/features/custom-instructions.md
@@ -5,9 +5,6 @@ Custom Instructions allow you to personalize how Roo behaves, providing specific
 ## What Are Custom Instructions?
 
 Custom Instructions define specific behaviors, preferences, and constraints beyond Roo's basic role definition. Examples include coding style, documentation standards, testing requirements, and workflow guidelines.
-:::info Rules Files
-Custom Instructions are simply .rules files. They use the common convention of `.clinerules`, `.cursorrules`, and `.windsurfrules` files, which can be placed in your workspace root for version control or configured through the UI.
- :::
 
 ## Setting Custom Instructions
 
@@ -29,7 +26,7 @@ These instructions only apply within your current workspace, allowing you to cus
 
 #### Workspace-Wide Instructions
 
-Workspace-wide instructions are defined through rule files in your workspace root, primarily using `.clinerules`. Additional support for `.cursorrules` and `.windsurfrules` is available for editor compatibility.
+Workspace-wide instructions can be defined in the Prompts tab or through a `.roorules` file in your workspace root.
 
 #### Mode-Specific Instructions
 
@@ -47,7 +44,7 @@ Mode-specific instructions can be set in two independent ways that can be used s
         If the mode itself is global (not workspace-specific), any custom instructions you set for it will also apply globally for that mode across all workspaces.
         :::
 
-2.  **Using Rule Files:** Create a `.clinerules-[mode]` file in your workspace root (e.g., `.clinerules-code`)
+2.  **Using Rule Files:** Create a `.roorules-[mode]` file in your workspace root (e.g., `.roorules-code`)
 
 When both tab instructions and rule files are set for a mode, both sets of instructions will be included in the system prompt.
 
@@ -64,10 +61,8 @@ The following additional instructions are provided by the user, and should be fo
 [Mode-specific Instructions]
 
 Rules:
-[.clinerules-{mode} rules]
-[.clinerules rules]
-[.cursorrules rules]
-[.windsurfrules rules]
+[.roorules-{mode} rules]
+[.roorules rules]
 ```
 
 ## Rules about .rules files
@@ -88,7 +83,7 @@ Rules:
 * "When adding new features to websites, ensure they are responsive and accessible"
 
 :::tip Pro Tip: File-Based Team Standards
-When working in team environments, placing `.clinerules` files under version control allows you to standardize Roo's behavior across your entire development team. This ensures consistent code style, documentation practices, and development workflows for everyone on the project.
+When working in team environments, placing `.roorules` files under version control allows you to standardize Roo's behavior across your entire development team. This ensures consistent code style, documentation practices, and development workflows for everyone on the project.
 :::
 
 ## Combining with Custom Modes

--- a/docs/features/custom-modes.md
+++ b/docs/features/custom-modes.md
@@ -18,7 +18,7 @@ Custom modes allow you to define:
 
 *   **A unique name and slug:** For easy identification
 *   **A role definition:** Placed at the beginning of the system prompt, this defines Roo's core expertise and personality for the mode. This placement is crucial as it shapes Roo's fundamental understanding and approach to tasks
-*   **Custom instructions:** Added at the end of the system prompt, these provide specific guidelines that modify or refine Roo's behavior. Unlike `.clinerules` files (which only add rules at the end), this structured placement of role and instructions allows for more nuanced control over Roo's responses
+*   **Custom instructions:** Added at the end of the system prompt, these provide specific guidelines that modify or refine Roo's behavior. Unlike `.roorules` files (which only add rules at the end), this structured placement of role and instructions allows for more nuanced control over Roo's responses
 *   **Allowed tools:** Which Roo Code tools the mode can use (e.g., read files, write files, execute commands)
 *   **File restrictions:** (Optional) Limit file access to specific file types or patterns (e.g., only allow editing `.md` files)
 
@@ -101,8 +101,8 @@ Common regex patterns:
 
 In addition to the `customInstructions` property in JSON, you can use a dedicated file for mode-specific instructions:
 
-1. Create a file named `.clinerules-{mode-slug}` in your workspace root
-   * Replace `{mode-slug}` with your mode's slug (e.g., `.clinerules-docs-writer`)
+1. Create a file named `.roorules-{mode-slug}` in your workspace root
+   * Replace `{mode-slug}` with your mode's slug (e.g., `.roorules-docs-writer`)
 2. Add your custom instructions to this file
 3. Roo Code will automatically apply these instructions to the specified mode
 
@@ -111,7 +111,7 @@ This approach is particularly useful for:
 * Managing instructions with version control
 * Allowing non-technical team members to modify instructions without editing JSON
 
-Note: If both `.clinerules-{mode-slug}` and the `customInstructions` property exist, they will be combined, with the file contents appended after the JSON property.
+Note: If both `.roorules-{mode-slug}` and the `customInstructions` property exist, they will be combined, with the file contents appended after the JSON property.
 
 ## Configuration Precedence
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update documentation to rename `.clinerules` to `.roorules` across multiple files for consistency.
> 
>   - **Documentation Update**:
>     - Renames `.clinerules` to `.roorules` in `faq.md`, `custom-instructions.md`, and `custom-modes.md`.
>     - Updates examples and instructions to use `.roorules` for defining custom instructions and modes.
>     - Clarifies usage of `.roorules` for workspace-wide and mode-specific instructions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code-Docs&utm_source=github&utm_medium=referral)<sup> for a22969d078130a992ccd7921407b551955af1620. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->