### PR TITLE
docs: clarify folder mention format and description in context mentions

### DIFF
--- a/docs/basic-usage/context-mentions.md
+++ b/docs/basic-usage/context-mentions.md
@@ -15,7 +15,7 @@ Context mentions are a powerful way to provide Roo Code with specific informatio
 | Mention Type | Format | Description | Example Usage |
 |--------------|--------|-------------|--------------|
 | **File** | `@/path/to/file.ts` | Includes file contents in request context | "Explain the function in @/src/utils.ts" |
-| **Folder** | `@/path/to/folder/` | Provides directory structure in tree format | "What files are in @/src/components/?" |
+| **Folder** | `@/path/to/folder` | Includes contents of all files directly in the folder (non-recursive) | "Analyze the code in @/src/components" |
 | **Problems** | `@problems` | Includes VS Code Problems panel diagnostics | "@problems Fix all errors in my code" |
 | **Terminal** | `@terminal` | Includes recent terminal command and output | "Fix the errors shown in @terminal" |
 | **Git Commit** | `@a1b2c3d` | References specific commit by hash | "What changed in commit @a1b2c3d?" |
@@ -39,14 +39,14 @@ Context mentions are a powerful way to provide Roo Code with specific informatio
 
 <img src="/img/context-mentions/context-mentions-2.png" alt="Folder mention example showing directory contents being referenced in the chat" width="600" />
 
-*Folder mentions display directory structure in a readable tree format.*
+*Folder mentions include the content of all files within the specified directory.*
 | Capability | Details |
 |------------|---------|
-| **Format** | `@/path/to/folder/` (note trailing slash) |
-| **Provides** | Hierarchical tree display with ├── and └── prefixes |
-| **Includes** | Immediate child files and directories (not recursive) |
-| **Best for** | Understanding project structure |
-| **Tip** | Use with file mentions to check specific file contents |
+| **Format** | `@/path/to/folder` (no trailing slash) |
+| **Provides** | Complete contents of all files within the directory |
+| **Includes** | Contents of all files directly within the folder (not recursive) |
+| **Best for** | Providing context from multiple files in a directory |
+| **Tip** | Be mindful of context window limits when mentioning large directories |
 
 ### Problems Mention
 


### PR DESCRIPTION
Modified in response to https://github.com/RooVetGit/Roo-Code/issues/2216 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Clarifies folder mention format and description in `context-mentions.md` to exclude trailing slash and specify non-recursive inclusion of file contents.
> 
>   - **Documentation**:
>     - In `context-mentions.md`, updated folder mention format to `@/path/to/folder` (no trailing slash).
>     - Clarified folder mention description to include contents of all files directly within the folder, non-recursive.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code-Docs&utm_source=github&utm_medium=referral)<sup> for 83b3853c83f8171709d3783720ffbcb9d0f8c38e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->