### PR TITLE
docs: Update prompt caching description for Gemini models in release …

### DIFF
--- a/docs/update-notes/v3.14.2.md
+++ b/docs/update-notes/v3.14.2.md
@@ -4,7 +4,7 @@ This release introduces prompt caching for Gemini, user control over caching for
 
 ## Gemini 2.5 Caching is HERE!
 
-*   **Prompt Caching for Gemini 2.5 Models:** Prompt caching is now available for supported Google Gemini 2.5 models when using the [Requesty](/providers/requesty), [Google Gemini](/providers/gemini), or [OpenRouter](/providers/openrouter) providers.
+*   **Prompt Caching for Gemini Models:** Prompt caching is now available for the `Gemini 1.5 Flash`, `Gemini 2.0 Flash`, and `Gemini 2.5 Pro Preview` models when using the [Requesty](/providers/requesty), [Google Gemini](/providers/gemini), or [OpenRouter](/providers/openrouter) providers (Vertex provider and `Gemini 2.5 Flash Preview` caching coming soon!)
 *   **Manual Caching Toggle (Google Gemini & OpenRouter Only):**
     *   For the **[Google Gemini](/providers/gemini)** and **[OpenRouter](/providers/openrouter)** providers specifically, a new checkbox allows you to manually enable prompt caching for supported Gemini 2.5 models.
         <img src="/img/v3.14.2/v3.14.2.png" alt="Prompt Caching Checkbox in Provider Settings" width="600" />

--- a/docs/update-notes/v3.14.md
+++ b/docs/update-notes/v3.14.md
@@ -2,7 +2,7 @@
 
 ## Gemini 2.5 Caching is HERE!
 
-*   **Prompt Caching for Gemini 2.5 Models:** Prompt caching is now available for supported Google Gemini 2.5 models when using the [Requesty](/providers/requesty), [Google Gemini](/providers/gemini), or [OpenRouter](/providers/openrouter) providers (Vertex coming soon!)
+*   **Prompt Caching for Gemini Models:** Prompt caching is now available for the `Gemini 1.5 Flash`, `Gemini 2.0 Flash`, and `Gemini 2.5 Pro Preview` models when using the [Requesty](/providers/requesty), [Google Gemini](/providers/gemini), or [OpenRouter](/providers/openrouter) providers (Vertex provider and `Gemini 2.5 Flash Preview` caching coming soon!)
 *   **Manual Caching Toggle (Google Gemini & OpenRouter Only):**
     *   For the **[Google Gemini](/providers/gemini)** and **[OpenRouter](/providers/openrouter)** providers specifically, a new checkbox allows you to manually enable prompt caching for supported Gemini 2.5 models.
         <img src="/img/v3.14.2/v3.14.2.png" alt="Prompt Caching Checkbox in Provider Settings" width="600" />


### PR DESCRIPTION
…notes
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Updated release notes to expand prompt caching description for additional Gemini models in versions 3.14 and 3.14.2.
> 
>   - **Release Notes Update**:
>     - Updated prompt caching description in `v3.14.2.md` and `v3.14.md` to include `Gemini 1.5 Flash`, `Gemini 2.0 Flash`, and `Gemini 2.5 Pro Preview` models.
>     - Clarified that caching for `Gemini 2.5 Flash Preview` and Vertex provider is coming soon.
>     - Manual caching toggle details for `Google Gemini` and `OpenRouter` providers remain unchanged.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code-Docs&utm_source=github&utm_medium=referral)<sup> for e08eed7b593a941effdcc972f4c2d69b65c17a80. You can [customize](https://app.ellipsis.dev/RooVetGit/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->