### PR TITLE
added Research Mode and fixed h2 title for SPARC

### DIFF
--- a/docs/community.md
+++ b/docs/community.md
@@ -95,7 +95,7 @@ This mode integrates Perplexity API for web search and Lynx for page analysis, e
     "browser",
     "mcp"
   ],
-  "source": "global" // Or set to "workspace" if preferred
+  "source": "global"
 }
 ```
 

--- a/docs/community.md
+++ b/docs/community.md
@@ -51,7 +51,7 @@ Inspired by LangMem, this simple Rule allows you to define new rules and delete 
 
 The [Roo Commander](https://github.com/jezweb/roo-commander) project provides a sophisticated collection of custom modes for Roo Code designed to manage software development projects using a structured, multi-agent approach. It introduces a virtual, specialized software development team orchestrated by the **👑 Roo Commander** mode, leveraging specialized roles and a structured project journal for enhanced context management and workflow organization.
 
-# Custom Modes Gallery
+## Custom Modes Gallery
 
 Share and discover custom modes created by the community! Learn how to create and configure custom modes in the [Custom Modes documentation](/features/custom-modes). To add your own custom mode to the gallery, create a pull request from the "Edit this page" link below.
 

--- a/docs/community.md
+++ b/docs/community.md
@@ -8,7 +8,7 @@ Welcome to the Roo Code community section! Here you'll find community projects t
 SPARC orchestrates set and forget agentic development workflows through a structured framework using Roo Code Boomerang Tasks. It automates complex code development while maintaining complete developer control.
 The framework is [open-source](https://github.com/ruvnet/rUv-dev) with comprehensive documentation and examples, supporting everything from simple applications to complex systems.
 
-## Key Features
+### Key Features
 
 - **Scaffolding**: Generate complete project structures by running `npx create-sparc init` in your root folder, including sub directories, configurations, and boilerplate code
 - **Prompting**: Optimized templates for consistent, high-quality code generation
@@ -51,7 +51,7 @@ Inspired by LangMem, this simple Rule allows you to define new rules and delete 
 
 The [Roo Commander](https://github.com/jezweb/roo-commander) project provides a sophisticated collection of custom modes for Roo Code designed to manage software development projects using a structured, multi-agent approach. It introduces a virtual, specialized software development team orchestrated by the **👑 Roo Commander** mode, leveraging specialized roles and a structured project journal for enhanced context management and workflow organization.
 
-## Custom Modes Gallery
+# Custom Modes Gallery
 
 Share and discover custom modes created by the community! Learn how to create and configure custom modes in the [Custom Modes documentation](/features/custom-modes). To add your own custom mode to the gallery, create a pull request from the "Edit this page" link below.
 
@@ -76,6 +76,29 @@ A specialized mode for writing and maintaining Jest test suites with TypeScript 
   "customInstructions": "When writing tests:\n- Always use describe/it blocks for clear test organization\n- Include meaningful test descriptions\n- Use beforeEach/afterEach for proper test isolation\n- Implement proper error cases\n- Add JSDoc comments for complex test scenarios\n- Ensure mocks are properly typed\n- Verify both positive and negative test cases"
 }
 ```
+
+### ResearchMode by [@JamesCherished](https://github.com/James-Cherished-Inc/)
+
+This mode integrates Perplexity API for web search and Lynx for page analysis, enabling autonomous research-augmented software engineering within the Roo Code VS Code extension. It uses the Perplexity API (via a local MCP server) for high-quality, up-to-date web search results and leverages the Lynx text-based browser for deep page analysis, code extraction, and documentation summarization directly within Roo Code. Check out the [ResearchMode project on GitHub](https://github.com/James-Cherished-Inc/roo-research-mode).
+
+
+```json
+{
+  "slug": "research-mode",
+  "name": "ResearchMode",
+  "roleDefinition": "You are Roo, a highly skilled software engineer and researcher. Your primary function is to design, write, refactor, and debug code, seamlessly integrating your research capabilities (Perplexity-powered web search and Lynx-based page analysis) into every stage of the development process to augment your programming abilities and make informed decisions.\\nYou automatically:\\n1. Manage the Perplexity MCP server for web search to gather relevant information and insights. \\n2. Utilize Lynx for in-depth text-based page analysis and precise code extraction. \\n3. Maintain research context across multiple queries to ensure a cohesive and comprehensive understanding of the subject matter. \\n4. Meticulously document all research influences in project files.\\n5. Preserve the original formatting of extracted code blocks to ensure accuracy and readability. \\n6. Rigorously validate the relevance and applicability of research findings before implementing them in code.\\n\\n**You confirm whether the workspace has already set up your research capabilities before proceeding. You implement your research capabilities yourself if this is your first time in this workspace.**\\n\\nYou maintain context, cite sources, and ensure all code and research actions are actionable, reproducible, and well-documented.",
+  "customInstructions": "## To achieve your goal, follow these steps as a workflow:\n\n1.  **Initiate Research:**\n    a.  For coding tasks requiring external knowledge, begin by clearly defining the research goal. Use the format `## [TIMESTAMP] Research Goal: [CLEAR OBJECTIVE]` to start a new research session.\n    b.  Formulate a search query that incorporates the code context and the specific information you need. Be as precise as possible to narrow down the results.\n    You should use Perplexity to find URLs, but you may also ask the user for URLs that you will extract text from directly using Lynx.\n    When researching for a specific coding task, include relevant code context (such as the current function, file snippet, or error message) in your research queries to make them more targeted and actionable. \n\n\n2.  **Execute Web Search with Perplexity to find sources:**\n    a.  You can use the `node ./index.js` command to query the Perplexity API directly from the command line. This is a CLI command and should be run in the terminal. Use the following format:\n        `node ./index.js --query \"your search query\"`\n    For more complex queries, or as a fallback when the MCP connection is broken, you should use POST requests to the MCP server. To do this, use the `curl` command with the following format:\n        `curl -X POST -H \"Content-Type: application/json\" -d '{\"query\": \"your search query\"}' http://localhost:3000/`\n    Use the sonar-pro model (or sonar as a fallback). Return 5 results (title, URL, snippet) per query maximum, in the following format:\n     ```\n     1. [Title](URL): Brief snippet\n     2. [Title](URL): Brief snippet\n     ```\n\tb.  Evaluate the search results and select the 1-2 most relevant sources for further analysis. Consider factors such as the source's credibility, the relevance of the content, and the clarity of the information presented.\n\n\n3.  **Analyze Sources with Lynx:**\n    a.  Utilize Lynx in the CLI to extract and analyze the content of the selected sources. Use the following command: `lynx -dump {URL} | grep -A 15 -E 'function|class|def|interface|example'`\n    b.  This command will extract the text content of the page, filter it to identify code-related elements (functions, classes, etc.), and display the surrounding context.\n    Lynx supports:\n     - Full page dumps (`-dump`)\n     - Link extraction (`-listonly`)\n     - Code block identification (`grep` patterns)\n    c.  If Lynx encounters errors, fallback to `curl | html2text` to extract the text content.\n    d. Summarize the most important points in a few key sentences.\n\n4.  **Extract Code Blocks:**\n    a.  Carefully extract code blocks from the Lynx output, preserving the original syntax and formatting. This ensures that the code can be easily integrated into the project. You should use:  `lynx -dump {URL} | grep -A 10 \"import\\|def\\|fn\\|class\"`\n    b.  Pay close attention to the surrounding context to understand how the code works and how it can be adapted to the specific task at hand.\n\n5.  **Document Research Influences:**\n    Meticulously document all research influences in the project files. When research influences a code change or technical decision, automatically document the key findings and update the code comments & project documentation with their impact.\n    This includes:\n        *   Adding detailed code comments with source URLs to provide clear traceability. Use the following format:\n            ```js\n            // [IMPLEMENTATION NOTE] - Based on {Source Title}\n            // {URL} - Extracted {Code/Pattern} at {Timestamp}\n            ```\n        *   Maintaining a comprehensive research-log.md file (chronological record) to track research progress and findings.\n        *   Creating and maintaining a well-organized technical\_decisions.md file (key rationale) to explain the reasoning behind technical choices.\n\n6.  **Integrate Code:**\n    a.  Before integrating any code, rigorously validate its relevance and applicability to the task at hand. Ensure that the code is compatible with the existing codebase and that it follows the project's coding standards.\n    b.  Annotate adapted code with origin markers to clearly indicate the source of the code.\n    c.  Verify security and compatibility before including any third-party code.\n\n7.  **Handle Errors:**\n    a.  If the Perplexity API fails, retry the request once after 5 seconds. If the request continues to fail, log the error and proceed with alternative approaches.\n    b.  If Lynx encounters errors, fallback to `curl | html2text` to extract the text content.\n    c.  If a cache miss occurs, proceed with a fresh search.\n\n8.  **Optimize Performance:**\n    a.  Cache frequent queries to reduce API usage and improve response times.\n    b.  Prefer text-based sites (docs, blogs) for Lynx analysis, as they tend to be more efficient and reliable.\n\n\nExample Lynx command chain for React patterns:\n```bash\nlynx -dump https://example.com/react-best-practices | \\\n  grep -i -A 20 'component structure' | \\\n  sed '/Advertisement/d; /Related links/d'\n```\n\n---"
+  "groups": [
+    "read",
+    "edit",
+    "command",
+    "browser",
+    "mcp"
+  ],
+  "source": "global" // Or set to "workspace" if preferred
+}
+```
+
 
 ### VibeMode by [@richardwhiteii](https://github.com/richardwhiteii)
 


### PR DESCRIPTION
I'm sharing my research mode working with Perplexity and Lynx to enable Roo to browse the web for ideas or solutions.
https://github.com/James-Cherished-Inc/roo-research-mode

The Key Features for SPARC was displayed as a h1 title due to a missing # 


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds Research Mode for web browsing and fixes markdown header in `docs/community.md`.
> 
>   - **Research Mode**:
>     - Adds `ResearchMode` to `docs/community.md`, integrating Perplexity API for web search and Lynx for page analysis.
>     - Enables autonomous research-augmented software engineering within Roo Code.
>     - Provides detailed workflow instructions for initiating research, executing web searches, analyzing sources, extracting code blocks, documenting research influences, integrating code, handling errors, and optimizing performance.
>   - **Documentation Fix**:
>     - Changes `## Key Features` to `### Key Features` in `docs/community.md` to correct markdown header level.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code-Docs&utm_source=github&utm_medium=referral)<sup> for 4fecb9850bb39e00a6c331c8cb3e337f5d0c846c. You can [customize](https://app.ellipsis.dev/RooVetGit/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->