### PR TITLE
docs: Add optional base URL instruction for OpenAI API setup

### DIFF
--- a/docs/providers/openai.md
+++ b/docs/providers/openai.md
@@ -37,6 +37,7 @@ Refer to the [OpenAI Models documentation](https://platform.openai.com/docs/mode
 2.  **Select Provider:** Choose "OpenAI" from the "API Provider" dropdown.
 3.  **Enter API Key:** Paste your OpenAI API key into the "OpenAI API Key" field.
 4.  **Select Model:** Choose your desired model from the "Model" dropdown.
+5.  **(Optional) Base URL:** If you need to use a custom base URL, enter the URL. Most people won't need to adjust this.
 
 ## Tips and Notes
 


### PR DESCRIPTION
Link PR: https://github.com/RooVetGit/Roo-Code/pull/3066
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds optional base URL configuration step to OpenAI API setup in documentation.
> 
>   - **Documentation Update**:
>     - Adds an optional step in `docs/providers/openai.md` for entering a custom base URL during OpenAI API setup.
>     - Clarifies that most users won't need to adjust the base URL.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code-Docs&utm_source=github&utm_medium=referral)<sup> for aa3d540547e888e2ef0b2a92a3117894281325f9. You can [customize](https://app.ellipsis.dev/RooVetGit/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->