### PR TITLE
docs:  Update connecting-api-provider.md

### DIFF
--- a/docs/getting-started/connecting-api-provider.md
+++ b/docs/getting-started/connecting-api-provider.md
@@ -31,7 +31,7 @@ LLM routers let you access multiple AI models with one API key, simplifying cost
 
 1. Go to [requesty.ai](https://requesty.ai/)
 2. Sign in with your Google account or email
-3. Navigate to the [API management page](https://app.requesty.ai/manage-api) and create a new key
+3. Navigate to the [API management page](https://app.requesty.ai/api-keys) and create a new key
 4. **Important:** Copy your API key immediately as it won't be displayed again
 
 <img src="/img/connecting-api-provider/connecting-api-provider-7.png" alt="Requesty API management page" width="600" />


### PR DESCRIPTION
update manage-api link of requesty provider Because the old link currently gives 404

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix broken link in `connecting-api-provider.md` for Requesty API management page.
> 
>   - **Documentation**:
>     - Update link in `connecting-api-provider.md` for Requesty API management page from `https://app.requesty.ai/manage-api` to `https://app.requesty.ai/api-keys` to fix 404 error.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code-Docs&utm_source=github&utm_medium=referral)<sup> for d9c0573e4e292bdb2678252b80fbbed4033e6450. You can [customize](https://app.ellipsis.dev/RooVetGit/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->