### PR TITLE
feat: add GPT-5-Codex support and keyboard shortcut for auto-approve …

### DIFF
--- a/docs/features/auto-approving-actions.mdx
+++ b/docs/features/auto-approving-actions.mdx
@@ -43,6 +43,24 @@ Auto-approve settings speed up your workflow by eliminating repetitive confirmat
 3. Use the All/None chips to bulk-select or clear permissions, or select individual tiles; you can keep Enabled On with "None" selected
 4. (Optional) Click the gear icon to open Settings for deeper per-permission controls
 
+### Keyboard Shortcut
+
+**Default shortcut:** `Cmd+Alt+A` (macOS) / `Ctrl+Alt+A` (Windows/Linux)
+
+Quickly toggle auto-approve on/off without using the mouse. This shortcut toggles the global "Enabled" state while preserving your permission selections.
+
+**To customize the shortcut:**
+1. Open VS Code Command Palette (`Cmd+Shift+P` / `Ctrl+Shift+P`)
+2. Search for "Preferences: Open Keyboard Shortcuts"
+3. Search for the command name (varies by language):
+   - English: "Toggle Auto-Approve"
+   - Other languages: Look for the localized equivalent
+4. Click the pencil icon next to the command
+5. Press your desired key combination
+6. Press Enter to save
+
+**Note:** The command name appears in your VS Code interface language. If you're using a non-English locale, the command will be translated accordingly.
+
 ---
 
 ## Auto-Approve Dropdown

--- a/docs/providers/openai.md
+++ b/docs/providers/openai.md
@@ -43,6 +43,17 @@ The GPT-5 models are OpenAI's most advanced, offering superior coding capabiliti
 * **`gpt-5-mini-2025-08-07`** - Faster, cost-efficient for well-defined tasks
 * **`gpt-5-nano-2025-08-07`** - Fastest, most cost-efficient option
 
+### GPT-5-Codex
+OpenAI's specialized coding model with advanced capabilities:
+
+**Key Features:**
+* **400K Token Context Window** - Process entire codebases and lengthy documentation
+* **Image Support** - Analyze screenshots, diagrams, and visual documentation
+* **Prompt Caching** - Reduced costs for repeated context through automatic caching
+* **Adaptive Reasoning** - Dynamically adjusts reasoning depth based on task complexity
+
+**Ideal for:** Large-scale code analysis, multimodal tasks requiring visual understanding, complex refactoring projects, and extensive codebase operations.
+
 ### GPT-4.1 Family
 Advanced multimodal models with balanced capabilities:
 
@@ -136,5 +147,6 @@ GPT-5 models maintain conversation context efficiently through response IDs, red
 
 ## Tips and Notes
 
-*   **Pricing:** Refer to the [OpenAI Pricing](https://openai.com/pricing) page for details on model costs.
+*   **Pricing:** Refer to the [OpenAI Pricing](https://openai.com/pricing) page for current model costs and discounts, including prompt caching.
 *   **Azure OpenAI Service:** If you'd like to use the Azure OpenAI service, please see our section on [OpenAI-compatible](/providers/openai-compatible) providers.
+*   **Context Optimization:** For GPT-5-Codex, leverage prompt caching by maintaining consistent context across requests to reduce costs significantly.

--- a/docs/update-notes/index.md
+++ b/docs/update-notes/index.md
@@ -20,6 +20,7 @@ image: /img/social-share.jpg
 ### Version 3.28
 
 *   [3.28](/update-notes/v3.28) (Combined)
+*   [3.28.6](/update-notes/v3.28.6) (2025-09-23)
 *   [3.28.5](/update-notes/v3.28.5) (2025-09-20)
 *   [3.28.4](/update-notes/v3.28.4) (2025-09-19)
 *   [3.28.3](/update-notes/v3.28.3) (2025-09-16)

--- a/docs/update-notes/v3.28.6.mdx
+++ b/docs/update-notes/v3.28.6.mdx
@@ -1,0 +1,38 @@
+---
+description: GPT-5-Codex arrives in OpenAI Native alongside localization tooling and UI refinements.
+keywords:
+  - roo code 3.28.6
+  - gpt-5-codex
+  - localization
+  - bug fixes
+  - release notes
+image: /img/social-share.jpg
+---
+
+# Roo Code 3.28.6 Release Notes (2025-09-23)
+
+This release adds GPT-5-Codex to OpenAI Native, sharpens localization coverage, and smooths UI workflows across languages.
+
+## GPT-5-Codex lands in OpenAI Native
+
+- **Work with repository-scale context**: Keep multi-file specs and long reviews in a single thread thanks to a 400k token window.
+- **Reuse prompts faster and include visuals**: Prompt caching and image support help you iterate on UI fixes without re-uploading context.
+- **Let the model adapt its effort**: GPT-5-Codex automatically balances quick responses for simple questions with deeper reasoning on complex builds.
+
+This gives teams a higher-capacity OpenAI option without extra configuration.[#8260](https://github.com/RooCodeInc/Roo-Code/pull/8260):
+
+
+> **📚 Documentation**: See [OpenAI Provider Guide](/providers/openai) for capabilities and setup guidance.
+
+## QOL Improvements
+
+* **Keyboard shortcut for auto-approve**: Toggle approvals with Cmd/Ctrl+Alt+A from anywhere in the editor, keeping focus on the code review flow (via [#8214](https://github.com/RooCodeInc/Roo-Code/pull/8214))
+* **Cleaner code blocks**: Removed the snippet language picker and word-wrap toggle so wrapped code is easier to read and copy across locales (via [#8208](https://github.com/RooCodeInc/Roo-Code/pull/8208))
+* **More readable reasoning blocks**: Added spacing before section headers inside reasoning transcripts to make long explanations easier to scan (via [#7868](https://github.com/RooCodeInc/Roo-Code/pull/7868))
+* **Translation checks cover package settings**: The missing translation finder now validates package.nls files for 17 locales to catch untranslated VS Code strings earlier (via [#8255](https://github.com/RooCodeInc/Roo-Code/pull/8255))
+
+## Bug Fixes
+
+* **Bare-metal evals stay signed in**: Roo provider tokens refresh automatically and the local evals app binds to port 3446 for predictable scripts (via [#8224](https://github.com/RooCodeInc/Roo-Code/pull/8224))
+* **Checkpoint text stays on one line**: Prevented multi-line wrapping in languages such as Chinese, Korean, Japanese, and Russian so the checkpoint UI stays compact (via [#8207](https://github.com/RooCodeInc/Roo-Code/pull/8207); reported in [#8206](https://github.com/RooCodeInc/Roo-Code/issues/8206))
+* **Ollama respects Modelfile num_ctx**: Roo now defers to your Modelfile’s context window to avoid GPU OOMs while still allowing explicit overrides when needed (via [#7798](https://github.com/RooCodeInc/Roo-Code/pull/7798); reported in [#7797](https://github.com/RooCodeInc/Roo-Code/issues/7797))

--- a/docs/update-notes/v3.28.mdx
+++ b/docs/update-notes/v3.28.mdx
@@ -52,14 +52,27 @@ Task Sync enables monitoring your local development environment from any device.
 
 > **Documentation**: See [Task Sync](/roo-code-cloud/task-sync), [Roomote Control Guide](/roo-code-cloud/roomote-control), and [Billing & Subscriptions](/roo-code-cloud/billing-subscriptions).
 
+## GPT-5-Codex lands in OpenAI Native
+
+- **Work with repository-scale context**: Keep multi-file specs and long reviews in a single thread thanks to a 400k token window.
+- **Reuse prompts faster and include visuals**: Prompt caching and image support help you iterate on UI fixes without re-uploading context.
+- **Let the model adapt its effort**: GPT-5-Codex automatically balances quick responses for simple questions with deeper reasoning on complex builds.
+
+This gives teams a higher-capacity OpenAI option without extra configuration.[#8260](https://github.com/RooCodeInc/Roo-Code/pull/8260):
+
+> **Documentation**: See [OpenAI Provider Guide](/providers/openai) for capabilities and setup guidance.
+
 ## QOL Improvements
 
+* **Auto-approve keyboard shortcut**: Toggle approvals with Cmd/Ctrl+Alt+A from anywhere in the editor so you can stay in the flow while reviewing changes (via [#8214](https://github.com/RooCodeInc/Roo-Code/pull/8214))
 * **Click-to-Edit Chat Messages**: Click directly on any message text to edit it, with ESC to cancel and improved padding consistency ([#7790](https://github.com/RooCodeInc/Roo-Code/pull/7790))
 * **Enhanced Reasoning Display**: The AI's thinking process now shows a persistent timer and displays reasoning content in clean italic text ([#7752](https://github.com/RooCodeInc/Roo-Code/pull/7752))
+* **Easier-to-scan reasoning transcripts**: Added clear line breaks before reasoning headers inside the UI so long thoughts are easier to skim (via [#7868](https://github.com/RooCodeInc/Roo-Code/pull/7868))
 * **Manual Auth URL Input**: Users in containerized environments can now paste authentication redirect URLs manually when automatic redirection fails ([#7805](https://github.com/RooCodeInc/Roo-Code/pull/7805))
 * **Active Mode Centering**: The mode selector dropdown now automatically centers the active mode when opened ([#7883](https://github.com/RooCodeInc/Roo-Code/pull/7883))
 * **Preserve First Message**: The first message containing slash commands or initial context is now preserved during conversation condensing instead of being replaced with a summary ([#7910](https://github.com/RooCodeInc/Roo-Code/pull/7910))
 * **Checkpoint Initialization Notifications**: You'll now receive clear notifications when checkpoint initialization fails, particularly with nested Git repositories ([#7766](https://github.com/RooCodeInc/Roo-Code/pull/7766))
+* **Translation coverage auditing**: The translation checker now validates package.nls locales by default to catch missing strings before release (via [#8255](https://github.com/RooCodeInc/Roo-Code/pull/8255))
 
 * Smaller and more subtle auto-approve UI (thanks brunobergher!) ([#7894](https://github.com/RooCodeInc/Roo-Code/pull/7894))
 * Disable Roomote Control on logout for better security ([#7976](https://github.com/RooCodeInc/Roo-Code/pull/7976))
@@ -74,10 +87,13 @@ Task Sync enables monitoring your local development environment from any device.
 * **Redesigned Message Feed**: Enjoy a cleaner, more readable chat interface with improved visual hierarchy that helps you focus on what matters ([#7985](https://github.com/RooCodeInc/Roo-Code/pull/7985))
 * **Responsive Auto-Approve**: The auto-approve dropdown now adapts to different window sizes with smart 1-2 column layouts, and tooltips show all enabled actions without truncation ([#8032](https://github.com/RooCodeInc/Roo-Code/pull/8032))
 * **Network Resilience**: Telemetry data now automatically retries on network failures, ensuring analytics and diagnostics aren't lost during connectivity issues ([#7597](https://github.com/RooCodeInc/Roo-Code/pull/7597))
-* **Code blocks wrap by default**: Code blocks now wrap text by default, improving readability when viewing long commands and code snippets ([#8194](https://github.com/RooCodeInc/Roo-Code/pull/8194))
+* **Code blocks wrap by default**: Code blocks now wrap text by default, and the snippet toolbar no longer includes language or wrap toggles, keeping snippets readable across locales (via [#8194](https://github.com/RooCodeInc/Roo-Code/pull/8194); [#8208](https://github.com/RooCodeInc/Roo-Code/pull/8208))
 
 ## Bug Fixes
 
+* **Roo provider stays signed in**: Roo provider tokens refresh automatically and the local evals app binds to port 3446 for predictable scripts (via [#8224](https://github.com/RooCodeInc/Roo-Code/pull/8224))
+* **Checkpoint text stays on one line**: Prevented multi-line wrapping in languages such as Chinese, Korean, Japanese, and Russian so the checkpoint UI stays compact (via [#8207](https://github.com/RooCodeInc/Roo-Code/pull/8207); reported in [#8206](https://github.com/RooCodeInc/Roo-Code/issues/8206))
+* **Ollama respects Modelfile num_ctx**: Roo now defers to your Modelfile’s context window to avoid GPU OOMs while still allowing explicit overrides when needed (via [#7798](https://github.com/RooCodeInc/Roo-Code/pull/7798); reported in [#7797](https://github.com/RooCodeInc/Roo-Code/issues/7797))
 * **Groq Context Window**: Fixed incorrect display of cached tokens in context window ([#7839](https://github.com/RooCodeInc/Roo-Code/pull/7839))
 * **Chat Message Operations**: Resolved duplication issues when editing messages and "Couldn't find timestamp" errors when deleting ([#7793](https://github.com/RooCodeInc/Roo-Code/pull/7793))
 * **UI Overlap**: Fixed CodeBlock button z-index to prevent overlap with popovers and configuration panels (thanks A0nameless0man!) ([#7783](https://github.com/RooCodeInc/Roo-Code/pull/7783))

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -223,6 +223,7 @@ const sidebars: SidebarsConfig = {
           label: '3.28',
           items: [
             { type: 'doc', id: 'update-notes/v3.28', label: '3.28 Combined' },
+            { type: 'doc', id: 'update-notes/v3.28.6', label: '3.28.6' },
             { type: 'doc', id: 'update-notes/v3.28.5', label: '3.28.5' },
             { type: 'doc', id: 'update-notes/v3.28.4', label: '3.28.4' },
             { type: 'doc', id: 'update-notes/v3.28.3', label: '3.28.3' },


### PR DESCRIPTION
…in v3.28.6 release notes
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds GPT-5-Codex support and keyboard shortcut for auto-approve in v3.28.6 release notes, with documentation updates and various improvements.
> 
>   - **Features**:
>     - Adds GPT-5-Codex support in `docs/providers/openai.md` with features like 400K token context window, image support, and adaptive reasoning.
>     - Introduces keyboard shortcut `Cmd+Alt+A` / `Ctrl+Alt+A` for toggling auto-approve in `docs/features/auto-approving-actions.mdx`.
>   - **Documentation**:
>     - Updates `docs/update-notes/index.md` and `docs/update-notes/v3.28.6.mdx` to include v3.28.6 release notes.
>     - Adds `v3.28.6` to `sidebars.ts` under version 3.28.
>   - **Quality of Life Improvements**:
>     - Removes snippet language picker and word-wrap toggle for cleaner code blocks.
>     - Adds spacing before section headers in reasoning transcripts for readability.
>     - Validates package.nls files for translation coverage.
>   - **Bug Fixes**:
>     - Ensures Roo provider tokens refresh automatically.
>     - Prevents multi-line wrapping in checkpoint UI for certain languages.
>     - Defers to Modelfile's `num_ctx` setting in Ollama to avoid GPU OOMs.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code-Docs&utm_source=github&utm_medium=referral)<sup> for e151a9a077b365325b3c2c39547fc7d8373ed26f. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->