### PR TITLE
chore(rules): update release-notes-writer rules XML

### DIFF
--- a/.roo/rules-release-notes-writer/1_main_workflow.xml
+++ b/.roo/rules-release-notes-writer/1_main_workflow.xml
@@ -91,7 +91,7 @@
       <step number="3">
         <action>Fetch PRs from GitHub using simplified approach</action>
         <skip_if>User provided PR list</skip_if>
-        <command><![CDATA[
+        <command>
 # Replace X.Y.Z with the actual version number
 TAG_INPUT="X.Y.Z"; TAG="v$(echo "$TAG_INPUT" | sed 's/^v//')"; \
 END=$(gh release view "$TAG" --repo RooCodeInc/Roo-Code --json publishedAt --jq '.publishedAt'); \
@@ -99,7 +99,7 @@ START=$(gh release list --repo RooCodeInc/Roo-Code --limit 1000 --json tagName,p
 gh pr list --repo RooCodeInc/Roo-Code --state merged --base main --limit 1000 \
   --json number,title,author,url,mergedAt \
   --jq 'map(select(.mergedAt >= "'"$START"'" and .mergedAt <= "'"$END"'")) | sort_by(.mergedAt)[] | [.number,.mergedAt,.author.login,.title,.url] | @tsv'
-        ]]></command>
+        </command>
         <output_description>
           Returns JSON array of PR objects sorted by merge date, including all metadata needed for PR processing
         </output_description>
@@ -132,7 +132,7 @@ gh pr list --repo RooCodeInc/Roo-Code --state merged --base main --limit 1000 \
             Wait for all subtasks to complete before proceeding to compilation phase.
           </iteration_approach>
         </implementation>
-        <message_template><![CDATA[
+        <message_template>
   Investigate PR #[number] for release notes v[version].
   1. Get PR details: gh pr view [number] --repo RooCodeInc/Roo-Code --json number,title,author,mergedAt,labels,body,url
   2. Extract linked issues from PR body
@@ -149,18 +149,18 @@ gh pr list --repo RooCodeInc/Roo-Code --state merged --base main --limit 1000 \
   
   CRITICAL: Never create/overwrite files, only append.
   MANDATORY: Insert the marker line '<!-- generated-by-subtask: true -->' immediately before the '---' separator in each PR entry.
-  ]]></message_template>
-        <todos_template><![CDATA[
+  </message_template>
+        <todos_template>
 [ ] Fetch PR #[number] details using gh pr view --repo RooCodeInc/Roo-Code
 [ ] Extract linked issues from PR body
 [ ] Get issue details for each linked issue
 [ ] Categorize the change (Feature/QOL/Bug Fix/Provider Update)
 [ ] Identify documentation needs
 [ ] Write analysis to .roo/tmp/release-notes/temp_pr_analysis_v[version].md
-        ]]></todos_template>
+        </todos_template>
       </subtask_pattern>
       
-      <output_format><![CDATA[
+      <output_format>
 ## PR #[number]: [Title]
 
 **Author**: [username]
@@ -173,12 +173,12 @@ gh pr list --repo RooCodeInc/Roo-Code --state merged --base main --limit 1000 \
 <!-- generated-by-subtask: true -->
 
 ---
-      ]]></output_format>
+      </output_format>
       
       <subtask_creation_example>
         <description>Example of creating subtasks for a PR list</description>
         <scenario>Given PRs: #1234, #1235, #1236 for version 3.20.1</scenario>
-        <implementation><![CDATA[
+        <implementation>
 <!-- For each PR, create a subtask like this: -->
 <new_task>
 <mode>release-notes-writer</mode>
@@ -195,7 +195,7 @@ Append analysis to .roo/tmp/release-notes/temp_pr_analysis_v3.20.1.md using inse
 [ ] Write to temp_pr_analysis_v3.20.1.md
 </todos>
 </new_task>
-        ]]></implementation>
+        </implementation>
         <critical_notes>
           - Parent creates temp files first
           - Each PR gets its own subtask
@@ -208,22 +208,22 @@ Append analysis to .roo/tmp/release-notes/temp_pr_analysis_v3.20.1.md using inse
       <description>Align the working PR set with the repository changelog for the selected version(s)</description>
       <step number="1">
         <action>Fetch changelog content for v[VERSION]</action>
-        <command><![CDATA[
+        <command>
 # Get the release body which contains the changelog
 gh release view vX.Y.Z --repo RooCodeInc/Roo-Code --json body | jq -r '.body'
-        ]]></command>
+        </command>
         <note>The release body contains the curated list of changes for this version</note>
       </step>
 
       <step number="1a">
         <action>Extract hero image URL candidates from release body and changelog; persist</action>
         <commands>
-          <save_body_to_file><![CDATA[
+          <save_body_to_file>
 # Save release body to a temp file for reuse
 mkdir -p .roo/tmp/release-notes
 gh release view vX.Y.Z --repo RooCodeInc/Roo-Code --json body --jq '.body' > .roo/tmp/release-notes/changelog_vX.Y.Z.md
-          ]]></save_body_to_file>
-          <fetch_changelog><![CDATA[
+          </save_body_to_file>
+          <fetch_changelog>
 # Fetch CHANGELOG.md at tag vX.Y.Z; fallback to main, then extract vX.Y.Z section
 TMP_DIR=".roo/tmp/release-notes"
 CHANGELOG_TAG_FILE="$TMP_DIR/CHANGELOG_vX.Y.Z.md"
@@ -254,8 +254,8 @@ if [ -s "$CHANGELOG_TAG_FILE" ]; then
 else
   : > "$SECTION_FILE"
 fi
-          ]]></fetch_changelog>
-          <extract_candidates><![CDATA[
+          </fetch_changelog>
+          <extract_candidates>
 # Build candidate list from both the release body and extracted changelog section (absolute and relative paths)
 CANDIDATES_FILE=".roo/tmp/release-notes/image_candidates_vX.Y.Z.txt"
 : > "$CANDIDATES_FILE"
@@ -266,7 +266,7 @@ grep -Eo '!\[[^]]*\]\(([^)]+)\)' .roo/tmp/release-notes/changelog_vX.Y.Z.md 2>/d
 
       <step number="1b">
         <action>Download hero image via curl to static/img/v[VERSION]/v[VERSION].png and persist frontmatter image path</action>
-<command><![CDATA[
+<command>
 VERSION="X.Y.Z"
 mkdir -p "static/img/v$VERSION"
 OUT="static/img/v$VERSION/v$VERSION.png"
@@ -277,7 +277,7 @@ if [ -s "$OUT" ]; then
 else
   echo "/img/social-share.jpg" > ".roo/tmp/release-notes/frontmatter_image_v$VERSION.txt"
 fi
-]]></command>
+</command>
         <notes>
           - If curl fails or the URL is invalid, the persisted path will be /img/social-share.jpg
           - Prefer PNG when multiple candidates are present
@@ -309,11 +309,11 @@ fi
           - Wait for all spawned subtasks to complete before proceeding
         </details>
         <commands>
-          <fetch><![CDATA[
+          <fetch>
 # For each referenced PR number N not present in .roo/tmp/release-notes/temp_pr_analysis_v[version].md:
 gh pr view N --repo RooCodeInc/Roo-Code --json number,title,author,mergedAt,labels,files
-          ]]></fetch>
-          <spawn_subtask><![CDATA[
+          </fetch>
+          <spawn_subtask>
 <new_task>
 <mode>release-notes-writer</mode>
 <message>Investigate PR #[NUMBER] (changelog-referenced, possibly out of original range) for release notes v[version]. Follow standard analysis and append to .roo/tmp/release-notes/temp_pr_analysis_v[version].md.</message>
@@ -326,7 +326,7 @@ gh pr view N --repo RooCodeInc/Roo-Code --json number,title,author,mergedAt,labe
 [ ] Write analysis to .roo/tmp/release-notes/temp_pr_analysis_v[version].md
 </todos>
 </new_task>
-          ]]></spawn_subtask>
+          </spawn_subtask>
       </step>
       
       <step number="2b">
@@ -358,7 +358,7 @@ gh pr view N --repo RooCodeInc/Roo-Code --json number,title,author,mergedAt,labe
       <step number="4">
         <action>Ask for inclusion policy</action>
         <tool>ask_followup_question</tool>
-        <template><![CDATA[
+        <template>
 <ask_followup_question>
 <question>Changelog alignment for v[VERSION]: [IN_COUNT] PRs referenced, [EX_COUNT] not referenced. How should I proceed?</question>
 <follow_up>
@@ -367,7 +367,7 @@ gh pr view N --repo RooCodeInc/Roo-Code --json number,title,author,mergedAt,labe
 <suggest>Review each excluded PR one by one so I can choose</suggest>
 </follow_up>
 </ask_followup_question>
-        ]]></template>
+        </template>
         <critical>Do not proceed until one of the provided options is selected.</critical>
       </step>
 
@@ -381,7 +381,7 @@ gh pr view N --repo RooCodeInc/Roo-Code --json number,title,author,mergedAt,labe
           - Options: "Yes, include this PR" or "No, skip this PR"
           - Build the final inclusion set as (in_changelog ∪ user_selected_inclusions)
         </loop>
-        <template><![CDATA[
+        <template>
 <ask_followup_question>
 <question>Include PR #[NUMBER] - [TITLE]? Short analysis: [WHY IT MATTERS].</question>
 <follow_up>
@@ -389,7 +389,7 @@ gh pr view N --repo RooCodeInc/Roo-Code --json number,title,author,mergedAt,labe
 <suggest>No, skip this PR</suggest>
 </follow_up>
 </ask_followup_question>
-        ]]></template>
+        </template>
         <completion>After the loop, proceed with the finalized PR set.</completion>
       </step>
       
@@ -417,7 +417,7 @@ gh pr view N --repo RooCodeInc/Roo-Code --json number,title,author,mergedAt,labe
       <step number="2">
         <action>Confirm feature highlighting with user</action>
         <tool>ask_followup_question</tool>
-        <template><![CDATA[
+        <template>
 I've analyzed all PRs for v[VERSION]. Here are the changes I found:
 
 **Major Features:**
@@ -428,7 +428,7 @@ I've analyzed all PRs for v[VERSION]. Here are the changes I found:
 **Other Changes:** [COUNT] items
 
 Which features should I highlight with expanded sections in the release notes?
-        ]]></template>
+        </template>
         <gating>
           <rule>Do not proceed until an explicit selection from the provided options is received.</rule>
           <rule>On freeform responses, re-ask with reformulated options derived from the user's input until a provided option is chosen.</rule>
@@ -458,9 +458,9 @@ Which features should I highlight with expanded sections in the release notes?
             - Follow .roorules Image Tag Format and use width="600"
             - If the persisted path is "/img/social-share.jpg", skip inline insertion
           </behavior>
-          <html_snippet><![CDATA[
+          <html_snippet>
 <img src="[FRONTMATTER_IMAGE_PATH]" alt="Roo Code v[VERSION] Release" width="600" />
-          ]]></html_snippet>
+          </html_snippet>
         </inline_hero_image>
       </step>
       
@@ -543,12 +543,12 @@ Which features should I highlight with expanded sections in the release notes?
         <step>Ask which to process</step>
       </steps>
       <commands>
-        <get_existing_docs><![CDATA[
+        <get_existing_docs>
 # Get existing documentation files
 ls docs/update-notes | grep -E '^v[0-9]+\.[0-9]+(\.[0-9]+)?\.(md|mdx)$' | sed -E 's/\.(md|mdx)$//'
-        ]]></get_existing_docs>
+        </get_existing_docs>
         
-        <get_releases_with_details><![CDATA[
+        <get_releases_with_details>
 # Get recent releases with full details in JSON array
 echo "["; first=1; \
 for tag in $(gh release list --repo RooCodeInc/Roo-Code --limit 20 --json tagName --jq '.[].tagName'); do
@@ -557,7 +557,7 @@ for tag in $(gh release list --repo RooCodeInc/Roo-Code --limit 20 --json tagNam
   first=0
 done; \
 echo "]"
-        ]]></get_releases_with_details>
+        </get_releases_with_details>
       </commands>
       <process>
         Compare the release list with existing docs to identify missing versions.
@@ -573,7 +573,7 @@ echo "]"
       This is simple, reliable, and captures all changes in a single command.
     </overview>
     
-    <the_command><![CDATA[
+    <the_command>
 # Replace X.Y.Z with the actual version number
 TAG_INPUT="X.Y.Z"; TAG="v$(echo "$TAG_INPUT" | sed 's/^v//')"; \
 END=$(gh release view "$TAG" --repo RooCodeInc/Roo-Code --json publishedAt --jq '.publishedAt'); \
@@ -581,7 +581,7 @@ START=$(gh release list --repo RooCodeInc/Roo-Code --limit 1000 --json tagName,p
 gh pr list --repo RooCodeInc/Roo-Code --state merged --base main --limit 1000 \
   --json number,title,author,url,mergedAt \
   --jq 'map(select(.mergedAt >= "'"$START"'" and .mergedAt <= "'"$END"'")) | sort_by(.mergedAt)[] | [.number,.mergedAt,.author.login,.title,.url] | @tsv'
-        ]]></the_command>
+        </the_command>
     
     <what_it_does>
       1. Gets the release timestamp for your version
@@ -621,7 +621,7 @@ grep -Eo 'https?://[^ )]+' .roo/tmp/release-notes/changelog_vX.Y.Z.md 2>/dev/nul
 
       <step number="1b">
         <action>Download hero image via curl to static/img/v[VERSION]/v[VERSION].png and persist frontmatter image path</action>
-<command><![CDATA[
+<command>
 VERSION="X.Y.Z"
 mkdir -p "static/img/v$VERSION"
 OUT="static/img/v$VERSION/v$VERSION.png"
@@ -632,7 +632,7 @@ if [ -s "$OUT" ]; then
 else
   echo "/img/social-share.jpg" > ".roo/tmp/release-notes/frontmatter_image_v$VERSION.txt"
 fi
-]]></command>
+</command>
         <notes>
           - If curl fails or the URL is invalid, the persisted path will be /img/social-share.jpg
           - Prefer PNG when multiple candidates are present
@@ -664,11 +664,11 @@ fi
           - Wait for all spawned subtasks to complete before proceeding
         </details>
         <commands>
-          <fetch><![CDATA[
+          <fetch>
 # For each referenced PR number N not present in .roo/tmp/release-notes/temp_pr_analysis_v[version].md:
 gh pr view N --repo RooCodeInc/Roo-Code --json number,title,author,mergedAt,labels,files
-          ]]></fetch>
-          <spawn_subtask><![CDATA[
+          </fetch>
+          <spawn_subtask>
 <new_task>
 <mode>release-notes-writer</mode>
 <message>Investigate PR #[NUMBER] (changelog-referenced, possibly out of original range) for release notes v[version]. Follow standard analysis and append to .roo/tmp/release-notes/temp_pr_analysis_v[version].md.</message>
@@ -681,7 +681,7 @@ gh pr view N --repo RooCodeInc/Roo-Code --json number,title,author,mergedAt,labe
 [ ] Write analysis to .roo/tmp/release-notes/temp_pr_analysis_v[version].md
 </todos>
 </new_task>
-          ]]></spawn_subtask>
+          </spawn_subtask>
       </step>
       
       <step number="2b">
@@ -713,7 +713,7 @@ gh pr view N --repo RooCodeInc/Roo-Code --json number,title,author,mergedAt,labe
       <step number="4">
         <action>Ask for inclusion policy</action>
         <tool>ask_followup_question</tool>
-        <template><![CDATA[
+        <template>
 <ask_followup_question>
 <question>Changelog alignment for v[VERSION]: [IN_COUNT] PRs referenced, [EX_COUNT] not referenced. How should I proceed?</question>
 <follow_up>
@@ -722,7 +722,7 @@ gh pr view N --repo RooCodeInc/Roo-Code --json number,title,author,mergedAt,labe
 <suggest>Review each excluded PR one by one so I can choose</suggest>
 </follow_up>
 </ask_followup_question>
-        ]]></template>
+        </template>
         <critical>Do not proceed until one of the provided options is selected.</critical>
       </step>
 
@@ -736,7 +736,7 @@ gh pr view N --repo RooCodeInc/Roo-Code --json number,title,author,mergedAt,labe
           - Options: "Yes, include this PR" or "No, skip this PR"
           - Build the final inclusion set as (in_changelog ∪ user_selected_inclusions)
         </loop>
-        <template><![CDATA[
+        <template>
 <ask_followup_question>
 <question>Include PR #[NUMBER] - [TITLE]? Short analysis: [WHY IT MATTERS].</question>
 <follow_up>
@@ -744,7 +744,7 @@ gh pr view N --repo RooCodeInc/Roo-Code --json number,title,author,mergedAt,labe
 <suggest>No, skip this PR</suggest>
 </follow_up>
 </ask_followup_question>
-        ]]></template>
+        </template>
         <completion>After the loop, proceed with the finalized PR set.</completion>
       </step>
       
@@ -772,7 +772,7 @@ gh pr view N --repo RooCodeInc/Roo-Code --json number,title,author,mergedAt,labe
       <step number="2">
         <action>Confirm feature highlighting with user</action>
         <tool>ask_followup_question</tool>
-        <template><![CDATA[
+        <template>
 I've analyzed all PRs for v[VERSION]. Here are the changes I found:
 
 **Major Features:**
@@ -783,7 +783,7 @@ I've analyzed all PRs for v[VERSION]. Here are the changes I found:
 **Other Changes:** [COUNT] items
 
 Which features should I highlight with expanded sections in the release notes?
-        ]]></template>
+        </template>
         <gating>
           <rule>Do not proceed until an explicit selection from the provided options is received.</rule>
           <rule>On freeform responses, re-ask with reformulated options derived from the user's input until a provided option is chosen.</rule>
@@ -885,12 +885,12 @@ Which features should I highlight with expanded sections in the release notes?
         <step>Ask which to process</step>
       </steps>
       <commands>
-        <get_existing_docs><![CDATA[
+        <get_existing_docs>
 # Get existing documentation files
 ls docs/update-notes | grep -E '^v[0-9]+\.[0-9]+(\.[0-9]+)?\.(md|mdx)$' | sed -E 's/\.(md|mdx)$//'
-        ]]></get_existing_docs>
+        </get_existing_docs>
         
-        <get_releases_with_details><![CDATA[
+        <get_releases_with_details>
 # Get recent releases with full details in JSON array
 echo "["; first=1; \
 for tag in $(gh release list --repo RooCodeInc/Roo-Code --limit 20 --json tagName --jq '.[].tagName'); do
@@ -899,7 +899,7 @@ for tag in $(gh release list --repo RooCodeInc/Roo-Code --limit 20 --json tagNam
   first=0
 done; \
 echo "]"
-        ]]></get_releases_with_details>
+        </get_releases_with_details>
       </commands>
       <process>
         Compare the release list with existing docs to identify missing versions.
@@ -915,7 +915,7 @@ echo "]"
       This is simple, reliable, and captures all changes in a single command.
     </overview>
     
-    <the_command><![CDATA[
+    <the_command>
 # Replace X.Y.Z with the actual version number
 TAG_INPUT="X.Y.Z"; TAG="v$(echo "$TAG_INPUT" | sed 's/^v//')"; \
 END=$(gh release view "$TAG" --repo RooCodeInc/Roo-Code --json publishedAt --jq '.publishedAt'); \
@@ -923,7 +923,7 @@ START=$(gh release list --repo RooCodeInc/Roo-Code --limit 1000 --json tagName,p
 gh pr list --repo RooCodeInc/Roo-Code --state merged --base main --limit 1000 \
   --json number,title,author,url,mergedAt \
   --jq 'map(select(.mergedAt >= "'"$START"'" and .mergedAt <= "'"$END"'")) | sort_by(.mergedAt)[] | [.number,.mergedAt,.author.login,.title,.url] | @tsv'
-        ]]></the_command>
+        </the_command>
     
     <what_it_does>
       1. Gets the release timestamp for your version
@@ -965,7 +965,7 @@ grep -Eo '!\[[^]]*\]\(([^)]+)\)' .roo/tmp/release-notes/CHANGELOG_section_vX.Y.Z
 
       <step number="1b">
         <action>Download hero image via curl to static/img/v[VERSION]/v[VERSION].png and persist frontmatter image path</action>
-<command><![CDATA[
+<command>
 VERSION="X.Y.Z"
 mkdir -p "static/img/v$VERSION"
 OUT="static/img/v$VERSION/v$VERSION.png"
@@ -976,7 +976,7 @@ if [ -s "$OUT" ]; then
 else
   echo "/img/social-share.jpg" > ".roo/tmp/release-notes/frontmatter_image_v$VERSION.txt"
 fi
-]]></command>
+</command>
         <notes>
           - If curl fails or the URL is invalid, the persisted path will be /img/social-share.jpg
           - Prefer PNG when multiple candidates are present
@@ -1008,11 +1008,11 @@ fi
           - Wait for all spawned subtasks to complete before proceeding
         </details>
         <commands>
-          <fetch><![CDATA[
+          <fetch>
 # For each referenced PR number N not present in .roo/tmp/release-notes/temp_pr_analysis_v[version].md:
 gh pr view N --repo RooCodeInc/Roo-Code --json number,title,author,mergedAt,labels,files
-          ]]></fetch>
-          <spawn_subtask><![CDATA[
+          </fetch>
+          <spawn_subtask>
 <new_task>
 <mode>release-notes-writer</mode>
 <message>Investigate PR #[NUMBER] (changelog-referenced, possibly out of original range) for release notes v[version]. Follow standard analysis and append to .roo/tmp/release-notes/temp_pr_analysis_v[version].md.</message>
@@ -1025,7 +1025,7 @@ gh pr view N --repo RooCodeInc/Roo-Code --json number,title,author,mergedAt,labe
 [ ] Write analysis to .roo/tmp/release-notes/temp_pr_analysis_v[version].md
 </todos>
 </new_task>
-          ]]></spawn_subtask>
+          </spawn_subtask>
       </step>
       
       <step number="2b">
@@ -1057,7 +1057,7 @@ gh pr view N --repo RooCodeInc/Roo-Code --json number,title,author,mergedAt,labe
       <step number="4">
         <action>Ask for inclusion policy</action>
         <tool>ask_followup_question</tool>
-        <template><![CDATA[
+        <template>
 <ask_followup_question>
 <question>Changelog alignment for v[VERSION]: [IN_COUNT] PRs referenced, [EX_COUNT] not referenced. How should I proceed?</question>
 <follow_up>
@@ -1066,7 +1066,7 @@ gh pr view N --repo RooCodeInc/Roo-Code --json number,title,author,mergedAt,labe
 <suggest>Review each excluded PR one by one so I can choose</suggest>
 </follow_up>
 </ask_followup_question>
-        ]]></template>
+        </template>
         <critical>Do not proceed until one of the provided options is selected.</critical>
       </step>
 
@@ -1080,7 +1080,7 @@ gh pr view N --repo RooCodeInc/Roo-Code --json number,title,author,mergedAt,labe
           - Options: "Yes, include this PR" or "No, skip this PR"
           - Build the final inclusion set as (in_changelog ∪ user_selected_inclusions)
         </loop>
-        <template><![CDATA[
+        <template>
 <ask_followup_question>
 <question>Include PR #[NUMBER] - [TITLE]? Short analysis: [WHY IT MATTERS].</question>
 <follow_up>
@@ -1088,7 +1088,7 @@ gh pr view N --repo RooCodeInc/Roo-Code --json number,title,author,mergedAt,labe
 <suggest>No, skip this PR</suggest>
 </follow_up>
 </ask_followup_question>
-        ]]></template>
+        </template>
         <completion>After the loop, proceed with the finalized PR set.</completion>
       </step>
       
@@ -1116,7 +1116,7 @@ gh pr view N --repo RooCodeInc/Roo-Code --json number,title,author,mergedAt,labe
       <step number="2">
         <action>Confirm feature highlighting with user</action>
         <tool>ask_followup_question</tool>
-        <template><![CDATA[
+        <template>
 I've analyzed all PRs for v[VERSION]. Here are the changes I found:
 
 **Major Features:**
@@ -1127,7 +1127,7 @@ I've analyzed all PRs for v[VERSION]. Here are the changes I found:
 **Other Changes:** [COUNT] items
 
 Which features should I highlight with expanded sections in the release notes?
-        ]]></template>
+        </template>
         <gating>
           <rule>Do not proceed until an explicit selection from the provided options is received.</rule>
           <rule>On freeform responses, re-ask with reformulated options derived from the user's input until a provided option is chosen.</rule>
@@ -1229,12 +1229,12 @@ Which features should I highlight with expanded sections in the release notes?
         <step>Ask which to process</step>
       </steps>
       <commands>
-        <get_existing_docs><![CDATA[
+        <get_existing_docs>
 # Get existing documentation files
 ls docs/update-notes | grep -E '^v[0-9]+\.[0-9]+(\.[0-9]+)?\.(md|mdx)$' | sed -E 's/\.(md|mdx)$//'
-        ]]></get_existing_docs>
+        </get_existing_docs>
         
-        <get_releases_with_details><![CDATA[
+        <get_releases_with_details>
 # Get recent releases with full details in JSON array
 echo "["; first=1; \
 for tag in $(gh release list --repo RooCodeInc/Roo-Code --limit 20 --json tagName --jq '.[].tagName'); do
@@ -1243,7 +1243,7 @@ for tag in $(gh release list --repo RooCodeInc/Roo-Code --limit 20 --json tagNam
   first=0
 done; \
 echo "]"
-        ]]></get_releases_with_details>
+        </get_releases_with_details>
       </commands>
       <process>
         Compare the release list with existing docs to identify missing versions.
@@ -1259,7 +1259,7 @@ echo "]"
       This is simple, reliable, and captures all changes in a single command.
     </overview>
     
-    <the_command><![CDATA[
+    <the_command>
 # Replace X.Y.Z with the actual version number
 TAG_INPUT="X.Y.Z"; TAG="v$(echo "$TAG_INPUT" | sed 's/^v//')"; \
 END=$(gh release view "$TAG" --repo RooCodeInc/Roo-Code --json publishedAt --jq '.publishedAt'); \
@@ -1267,7 +1267,7 @@ START=$(gh release list --repo RooCodeInc/Roo-Code --limit 1000 --json tagName,p
 gh pr list --repo RooCodeInc/Roo-Code --state merged --base main --limit 1000 \
   --json number,title,author,url,mergedAt \
   --jq 'map(select(.mergedAt >= "'"$START"'" and .mergedAt <= "'"$END"'")) | sort_by(.mergedAt)[] | [.number,.mergedAt,.author.login,.title,.url] | @tsv'
-        ]]></the_command>
+        </the_command>
     
     <what_it_does>
       1. Gets the release timestamp for your version
@@ -1307,7 +1307,7 @@ grep -Eo 'https?://[^ )]+' .roo/tmp/release-notes/CHANGELOG_section_vX.Y.Z.md 2>
 
       <step number="1b">
         <action>Download hero image via curl to static/img/v[VERSION]/v[VERSION].png and persist frontmatter image path</action>
-<command><![CDATA[
+<command>
 VERSION="X.Y.Z"
 mkdir -p "static/img/v$VERSION"
 OUT="static/img/v$VERSION/v$VERSION.png"
@@ -1318,7 +1318,7 @@ if [ -s "$OUT" ]; then
 else
   echo "/img/social-share.jpg" > ".roo/tmp/release-notes/frontmatter_image_v$VERSION.txt"
 fi
-]]></command>
+</command>
         <notes>
           - If curl fails or the URL is invalid, the persisted path will be /img/social-share.jpg
           - Prefer PNG when multiple candidates are present
@@ -1350,11 +1350,11 @@ fi
           - Wait for all spawned subtasks to complete before proceeding
         </details>
         <commands>
-          <fetch><![CDATA[
+          <fetch>
 # For each referenced PR number N not present in .roo/tmp/release-notes/temp_pr_analysis_v[version].md:
 gh pr view N --repo RooCodeInc/Roo-Code --json number,title,author,mergedAt,labels,files
-          ]]></fetch>
-          <spawn_subtask><![CDATA[
+          </fetch>
+          <spawn_subtask>
 <new_task>
 <mode>release-notes-writer</mode>
 <message>Investigate PR #[NUMBER] (changelog-referenced, possibly out of original range) for release notes v[version]. Follow standard analysis and append to .roo/tmp/release-notes/temp_pr_analysis_v[version].md.</message>
@@ -1367,7 +1367,7 @@ gh pr view N --repo RooCodeInc/Roo-Code --json number,title,author,mergedAt,labe
 [ ] Write analysis to .roo/tmp/release-notes/temp_pr_analysis_v[version].md
 </todos>
 </new_task>
-          ]]></spawn_subtask>
+          </spawn_subtask>
       </step>
       
       <step number="2b">
@@ -1399,7 +1399,7 @@ gh pr view N --repo RooCodeInc/Roo-Code --json number,title,author,mergedAt,labe
       <step number="4">
         <action>Ask for inclusion policy</action>
         <tool>ask_followup_question</tool>
-        <template><![CDATA[
+        <template>
 <ask_followup_question>
 <question>Changelog alignment for v[VERSION]: [IN_COUNT] PRs referenced, [EX_COUNT] not referenced. How should I proceed?</question>
 <follow_up>
@@ -1408,7 +1408,7 @@ gh pr view N --repo RooCodeInc/Roo-Code --json number,title,author,mergedAt,labe
 <suggest>Review each excluded PR one by one so I can choose</suggest>
 </follow_up>
 </ask_followup_question>
-        ]]></template>
+        </template>
         <critical>Do not proceed until one of the provided options is selected.</critical>
       </step>
 
@@ -1422,7 +1422,7 @@ gh pr view N --repo RooCodeInc/Roo-Code --json number,title,author,mergedAt,labe
           - Options: "Yes, include this PR" or "No, skip this PR"
           - Build the final inclusion set as (in_changelog ∪ user_selected_inclusions)
         </loop>
-        <template><![CDATA[
+        <template>
 <ask_followup_question>
 <question>Include PR #[NUMBER] - [TITLE]? Short analysis: [WHY IT MATTERS].</question>
 <follow_up>
@@ -1430,7 +1430,7 @@ gh pr view N --repo RooCodeInc/Roo-Code --json number,title,author,mergedAt,labe
 <suggest>No, skip this PR</suggest>
 </follow_up>
 </ask_followup_question>
-        ]]></template>
+        </template>
         <completion>After the loop, proceed with the finalized PR set.</completion>
       </step>
       
@@ -1458,7 +1458,7 @@ gh pr view N --repo RooCodeInc/Roo-Code --json number,title,author,mergedAt,labe
       <step number="2">
         <action>Confirm feature highlighting with user</action>
         <tool>ask_followup_question</tool>
-        <template><![CDATA[
+        <template>
 I've analyzed all PRs for v[VERSION]. Here are the changes I found:
 
 **Major Features:**
@@ -1469,7 +1469,7 @@ I've analyzed all PRs for v[VERSION]. Here are the changes I found:
 **Other Changes:** [COUNT] items
 
 Which features should I highlight with expanded sections in the release notes?
-        ]]></template>
+        </template>
         <gating>
           <rule>Do not proceed until an explicit selection from the provided options is received.</rule>
           <rule>On freeform responses, re-ask with reformulated options derived from the user's input until a provided option is chosen.</rule>
@@ -1571,12 +1571,12 @@ Which features should I highlight with expanded sections in the release notes?
         <step>Ask which to process</step>
       </steps>
       <commands>
-        <get_existing_docs><![CDATA[
+        <get_existing_docs>
 # Get existing documentation files
 ls docs/update-notes | grep -E '^v[0-9]+\.[0-9]+(\.[0-9]+)?\.(md|mdx)$' | sed -E 's/\.(md|mdx)$//'
-        ]]></get_existing_docs>
+        </get_existing_docs>
         
-        <get_releases_with_details><![CDATA[
+        <get_releases_with_details>
 # Get recent releases with full details in JSON array
 echo "["; first=1; \
 for tag in $(gh release list --repo RooCodeInc/Roo-Code --limit 20 --json tagName --jq '.[].tagName'); do
@@ -1585,7 +1585,7 @@ for tag in $(gh release list --repo RooCodeInc/Roo-Code --limit 20 --json tagNam
   first=0
 done; \
 echo "]"
-        ]]></get_releases_with_details>
+        </get_releases_with_details>
       </commands>
       <process>
         Compare the release list with existing docs to identify missing versions.
@@ -1601,7 +1601,7 @@ echo "]"
       This is simple, reliable, and captures all changes in a single command.
     </overview>
     
-    <the_command><![CDATA[
+    <the_command>
 # Replace X.Y.Z with the actual version number
 TAG_INPUT="X.Y.Z"; TAG="v$(echo "$TAG_INPUT" | sed 's/^v//')"; \
 END=$(gh release view "$TAG" --repo RooCodeInc/Roo-Code --json publishedAt --jq '.publishedAt'); \
@@ -1609,7 +1609,7 @@ START=$(gh release list --repo RooCodeInc/Roo-Code --limit 1000 --json tagName,p
 gh pr list --repo RooCodeInc/Roo-Code --state merged --base main --limit 1000 \
   --json number,title,author,url,mergedAt \
   --jq 'map(select(.mergedAt >= "'"$START"'" and .mergedAt <= "'"$END"'")) | sort_by(.mergedAt)[] | [.number,.mergedAt,.author.login,.title,.url] | @tsv'
-        ]]></the_command>
+        </the_command>
     
     <what_it_does>
       1. Gets the release timestamp for your version
@@ -1649,7 +1649,7 @@ grep -Eo '(/[^ )]+|[A-Za-z0-9_./-]+)\.(png|jpe?g|gif|webp)' .roo/tmp/release-not
 if [ -s "$CANDIDATES_FILE" ]; then
   sort -u "$CANDIDATES_FILE" > "$CANDIDATES_FILE.tmp" && mv "$CANDIDATES_FILE.tmp" "$CANDIDATES_FILE"
 fi
-          ]]></extract_candidates>
+          </extract_candidates>
         </commands>
         <output>
           <file>.roo/tmp/release-notes/image_candidates_v[version].txt</file>
@@ -1659,7 +1659,7 @@ fi
 
       <step number="1b">
         <action>Download hero image via curl to static/img/v[VERSION]/v[VERSION].png and persist frontmatter image path</action>
-<command><![CDATA[
+<command>
 VERSION="X.Y.Z"
 mkdir -p "static/img/v$VERSION"
 OUT="static/img/v$VERSION/v$VERSION.png"
@@ -1670,7 +1670,7 @@ if [ -s "$OUT" ]; then
 else
   echo "/img/social-share.jpg" > ".roo/tmp/release-notes/frontmatter_image_v$VERSION.txt"
 fi
-]]></command>
+</command>
         <notes>
           - If curl fails or the URL is invalid, the persisted path will be /img/social-share.jpg
           - Prefer PNG when multiple candidates are present
@@ -1702,11 +1702,11 @@ fi
           - Wait for all spawned subtasks to complete before proceeding
         </details>
         <commands>
-          <fetch><![CDATA[
+          <fetch>
 # For each referenced PR number N not present in .roo/tmp/release-notes/temp_pr_analysis_v[version].md:
 gh pr view N --repo RooCodeInc/Roo-Code --json number,title,author,mergedAt,labels,files
-          ]]></fetch>
-          <spawn_subtask><![CDATA[
+          </fetch>
+          <spawn_subtask>
 <new_task>
 <mode>release-notes-writer</mode>
 <message>Investigate PR #[NUMBER] (changelog-referenced, possibly out of original range) for release notes v[version]. Follow standard analysis and append to .roo/tmp/release-notes/temp_pr_analysis_v[version].md.</message>
@@ -1719,7 +1719,7 @@ gh pr view N --repo RooCodeInc/Roo-Code --json number,title,author,mergedAt,labe
 [ ] Write analysis to .roo/tmp/release-notes/temp_pr_analysis_v[version].md
 </todos>
 </new_task>
-          ]]></spawn_subtask>
+          </spawn_subtask>
       </step>
       
       <step number="2b">
@@ -1751,7 +1751,7 @@ gh pr view N --repo RooCodeInc/Roo-Code --json number,title,author,mergedAt,labe
       <step number="4">
         <action>Ask for inclusion policy</action>
         <tool>ask_followup_question</tool>
-        <template><![CDATA[
+        <template>
 <ask_followup_question>
 <question>Changelog alignment for v[VERSION]: [IN_COUNT] PRs referenced, [EX_COUNT] not referenced. How should I proceed?</question>
 <follow_up>
@@ -1760,7 +1760,7 @@ gh pr view N --repo RooCodeInc/Roo-Code --json number,title,author,mergedAt,labe
 <suggest>Review each excluded PR one by one so I can choose</suggest>
 </follow_up>
 </ask_followup_question>
-        ]]></template>
+        </template>
         <critical>Do not proceed until one of the provided options is selected.</critical>
       </step>
 
@@ -1774,7 +1774,7 @@ gh pr view N --repo RooCodeInc/Roo-Code --json number,title,author,mergedAt,labe
           - Options: "Yes, include this PR" or "No, skip this PR"
           - Build the final inclusion set as (in_changelog ∪ user_selected_inclusions)
         </loop>
-        <template><![CDATA[
+        <template>
 <ask_followup_question>
 <question>Include PR #[NUMBER] - [TITLE]? Short analysis: [WHY IT MATTERS].</question>
 <follow_up>
@@ -1782,7 +1782,7 @@ gh pr view N --repo RooCodeInc/Roo-Code --json number,title,author,mergedAt,labe
 <suggest>No, skip this PR</suggest>
 </follow_up>
 </ask_followup_question>
-        ]]></template>
+        </template>
         <completion>After the loop, proceed with the finalized PR set.</completion>
       </step>
       
@@ -1810,7 +1810,7 @@ gh pr view N --repo RooCodeInc/Roo-Code --json number,title,author,mergedAt,labe
       <step number="2">
         <action>Confirm feature highlighting with user</action>
         <tool>ask_followup_question</tool>
-        <template><![CDATA[
+        <template>
 I've analyzed all PRs for v[VERSION]. Here are the changes I found:
 
 **Major Features:**
@@ -1821,7 +1821,7 @@ I've analyzed all PRs for v[VERSION]. Here are the changes I found:
 **Other Changes:** [COUNT] items
 
 Which features should I highlight with expanded sections in the release notes?
-        ]]></template>
+        </template>
         <gating>
           <rule>Do not proceed until an explicit selection from the provided options is received.</rule>
           <rule>On freeform responses, re-ask with reformulated options derived from the user's input until a provided option is chosen.</rule>
@@ -1923,12 +1923,12 @@ Which features should I highlight with expanded sections in the release notes?
         <step>Ask which to process</step>
       </steps>
       <commands>
-        <get_existing_docs><![CDATA[
+        <get_existing_docs>
 # Get existing documentation files
 ls docs/update-notes | grep -E '^v[0-9]+\.[0-9]+(\.[0-9]+)?\.(md|mdx)$' | sed -E 's/\.(md|mdx)$//'
-        ]]></get_existing_docs>
+        </get_existing_docs>
         
-        <get_releases_with_details><![CDATA[
+        <get_releases_with_details>
 # Get recent releases with full details in JSON array
 echo "["; first=1; \
 for tag in $(gh release list --repo RooCodeInc/Roo-Code --limit 20 --json tagName --jq '.[].tagName'); do
@@ -1937,7 +1937,7 @@ for tag in $(gh release list --repo RooCodeInc/Roo-Code --limit 20 --json tagNam
   first=0
 done; \
 echo "]"
-        ]]></get_releases_with_details>
+        </get_releases_with_details>
       </commands>
       <process>
         Compare the release list with existing docs to identify missing versions.
@@ -1957,7 +1957,7 @@ echo "]"
       This is simple, reliable, and captures all changes in a single command.
     </overview>
     
-    <the_command><![CDATA[
+    <the_command>
 # Replace X.Y.Z with the actual version number
 TAG_INPUT="X.Y.Z"; TAG="v$(echo "$TAG_INPUT" | sed 's/^v//')"; \
 END=$(gh release view "$TAG" --repo RooCodeInc/Roo-Code --json publishedAt --jq '.publishedAt'); \
@@ -1965,7 +1965,7 @@ START=$(gh release list --repo RooCodeInc/Roo-Code --limit 1000 --json tagName,p
 gh pr list --repo RooCodeInc/Roo-Code --state merged --base main --limit 1000 \
   --json number,title,author,url,mergedAt \
   --jq 'map(select(.mergedAt >= "'"$START"'" and .mergedAt <= "'"$END"'")) | sort_by(.mergedAt)[] | [.number,.mergedAt,.author.login,.title,.url] | @tsv'
-        ]]></the_command>
+        </the_command>
     
     <what_it_does>
       1. Gets the release timestamp for your version

--- a/.roo/rules-release-notes-writer/2_content_standards.xml
+++ b/.roo/rules-release-notes-writer/2_content_standards.xml
@@ -19,7 +19,7 @@
 
     <required_elements>
       <element name="frontmatter">
-        <format><![CDATA[
+        <format>
 ---
 description: A concise summary of the release.
 keywords:
@@ -28,7 +28,7 @@ keywords:
   - bug fixes
 image: /img/social-share.jpg
 ---
-        ]]></format>
+        </format>
       </element>
       
       <element name="title">
@@ -52,9 +52,9 @@ image: /img/social-share.jpg
           - Use an HTML image tag per site rules with width="600"
           - Set src from .roo/tmp/release-notes/frontmatter_image_v[version].txt and alt to "Roo Code v[VERSION] Release"
         </rules>
-        <template><![CDATA[
+        <template>
 <img src="/img/vX.Y.Z/vX.Y.Z.png" alt="Roo Code vX.Y.Z Release" width="600" />
-        ]]></template>
+        </template>
       </element>
     </required_elements>
   </file_structure>
@@ -70,7 +70,7 @@ image: /img/social-share.jpg
       <category name="major_features">
         <criteria>New functionality changing user experience</criteria>
         <format>Own ## heading with expanded description</format>
-        <template><![CDATA[
+        <template>
 ## [Feature Name]
 
 We've [improvement description] (thanks [contributors]!) ([#PR](link)):
@@ -81,7 +81,7 @@ We've [improvement description] (thanks [contributors]!) ([#PR](link)):
 [Concluding sentence about impact]
 
 > **📚 Documentation**: See [Feature Guide](/path/to/feature) for detailed usage instructions.
-        ]]></template>
+        </template>
       </category>
       
       <category name="qol_improvements">
@@ -113,7 +113,7 @@ We've [improvement description] (thanks [contributors]!) ([#PR](link)):
   <content_formatting>
     <expanded_sections>
       <description>Major features with details</description>
-      <format><![CDATA[
+      <format>
 ## Feature Name
 
 Description of what the feature does (thanks contributor!) ([#PR](link)):
@@ -124,17 +124,17 @@ Description of what the feature does (thanks contributor!) ([#PR](link)):
 Concluding sentence about the benefit.
 
 > **📚 Documentation**: See [Feature Guide](/path/to/feature) for detailed usage.
-      ]]></format>
+      </format>
     </expanded_sections>
 
     <grouped_sections>
       <description>Smaller fixes and improvements</description>
-      <format><![CDATA[
+      <format>
 ## Section Name
 
 * **Item Name**: Single-line description (thanks contributor!) ([#PR](link))
 * **Another Item**: Another description ([#PR](link))
-      ]]></format>
+      </format>
     </grouped_sections>
 
     <contributor_acknowledgments>
@@ -217,12 +217,12 @@ Concluding sentence about the benefit.
   <documentation_links>
     <patterns>
       <inline>[Feature Name](/path/to/feature)</inline>
-      <see_also><![CDATA[
+      <see_also>
 > **📚 Documentation**: See [Feature Guide](/path) for detailed usage instructions.
-      ]]></see_also>
-      <migration><![CDATA[
+      </see_also>
+      <migration>
 > **🔄 Migration Guide**: If upgrading from v[OLD], see our [migration guide](/migration/vX-to-vY).
-      ]]></migration>
+      </migration>
     </patterns>
     <auto_linking>
       - Modes: /features/modes/[mode-slug]
@@ -289,12 +289,12 @@ Concluding sentence about the benefit.
       </element>
 
       <element name="footer_blurb">
-        <format_single><![CDATA[
+        <format_single>
 See full release notes [vX.Y.Z](https://docs.roocode.com/update-notes/vX.Y.Z)
-        ]]></format_single>
-        <format_combined><![CDATA[
+        </format_single>
+        <format_combined>
 See full release notes [vX.Y.Z](https://docs.roocode.com/update-notes/vX.Y.Z) | [vX.Y.Z](https://docs.roocode.com/update-notes/vX.Y.Z)
-        ]]></format_combined>
+        </format_combined>
         <rules>
           - Use markdown inline links with the version as the anchor text
           - For multiple versions, join links with " | "
@@ -362,12 +362,12 @@ See full release notes [vX.Y.Z](https://docs.roocode.com/update-notes/vX.Y.Z) | 
       </element>
 
       <element name="footer_blurb">
-        <format_single><![CDATA[
+        <format_single>
 See full release notes [vX.Y.Z](https://docs.roocode.com/update-notes/vX.Y.Z)
-        ]]></format_single>
-        <format_combined><![CDATA[
+        </format_single>
+        <format_combined>
 See full release notes [vX.Y.Z](https://docs.roocode.com/update-notes/vX.Y.Z) | [vX.Y.Z](https://docs.roocode.com/update-notes/vX.Y.Z)
-        ]]></format_combined>
+        </format_combined>
       </element>
     </structure>
 

--- a/.roo/rules-release-notes-writer/3_user_interactions.xml
+++ b/.roo/rules-release-notes-writer/3_user_interactions.xml
@@ -8,7 +8,7 @@
     <point name="feature_selection">
       <when>After PR analysis, before writing release notes</when>
       <purpose>Verify which features to highlight</purpose>
-      <template><![CDATA[
+      <template>
 <ask_followup_question>
 <question>I've analyzed all PRs for v[VERSION]. Here are the changes I found:
 
@@ -27,13 +27,13 @@ Which features should I highlight with expanded sections in the release notes?</
 <suggest>Let me specify which features to expand</suggest>
 </follow_up>
 </ask_followup_question>
-      ]]></template>
+      </template>
       <gating_rules>
         <rule priority="CRITICAL">Do not proceed unless the response clearly matches one of the provided options.</rule>
         <rule priority="HIGH">If the user types a freeform response, re-ask using ask_followup_question with options reformulated from their input; require selection of one provided option.</rule>
         <rule>Repeat this gating loop until a provided option is explicitly selected.</rule>
       </gating_rules>
-      <fallback_prompt><![CDATA[
+      <fallback_prompt>
 <ask_followup_question>
 <question>To proceed I need an explicit selection. Based on your input, which option should I follow?</question>
 <follow_up>
@@ -43,37 +43,41 @@ Which features should I highlight with expanded sections in the release notes?</
 <suggest>Let me specify which features to expand</suggest>
 </follow_up>
 </ask_followup_question>
-      ]]></fallback_prompt>
+      </fallback_prompt>
     </point>
 
     <point name="changelog_alignment">
       <when>After fetching PRs and before feature selection</when>
       <purpose>Partition PRs by presence in the changelog and select inclusion policy</purpose>
       <summary>
-        Present counts and reasons for exclusion, then offer three paths:
-        - Only changelog PRs
+        Present counts partitioned as:
+        - Linked (explicit or confidently auto‑matched)
+        - Ambiguous (needs review)
+        - Unlinked
+        Then offer three paths:
+        - Only linked PRs
+        - Linked + review ambiguous
         - All PRs
-        - Review excluded PRs one by one
       </summary>
-      <template_inclusion_policy><![CDATA[
+      <template_inclusion_policy>
 <ask_followup_question>
-<question>Changelog alignment for v[VERSION]: [IN_COUNT] PRs referenced, [EX_COUNT] not referenced. How should I proceed?</question>
+<question>Changelog alignment v[VERSION]: [IN_COUNT] linked, [AMBIG_COUNT] ambiguous, [EX_COUNT] unlinked. Choose how to proceed.</question>
 <follow_up>
-<suggest>Only include the PRs referenced in the changelog</suggest>
+<suggest>Proceed with linked PRs only; skip ambiguous and unlinked</suggest>
+<suggest>Include linked PRs and review the [AMBIG_COUNT] ambiguous items</suggest>
 <suggest>Include all PRs from the date range</suggest>
-<suggest>Review each excluded PR one by one so I can choose</suggest>
 </follow_up>
 </ask_followup_question>
-      ]]></template_inclusion_policy>
-      <template_per_pr_review><![CDATA[
+      </template_inclusion_policy>
+      <template_per_pr_review>
 <ask_followup_question>
-<question>Include PR #[NUMBER] - [TITLE]? Short analysis: [USER IMPACT / WHY IT MATTERS].</question>
+<question>Review ambiguous item: include PR #[NUMBER] - [TITLE]? Short analysis: [USER IMPACT / WHY IT MATTERS].</question>
 <follow_up>
 <suggest>Yes, include this PR</suggest>
 <suggest>No, skip this PR</suggest>
 </follow_up>
 </ask_followup_question>
-      ]]></template_per_pr_review>
+      </template_per_pr_review>
       <gating_rules>
         <rule priority="CRITICAL">Do not proceed until an explicit option is selected.</rule>
         <rule priority="HIGH">For freeform answers, re-ask with options that reflect the user's intent; require selection.</rule>
@@ -84,7 +88,7 @@ Which features should I highlight with expanded sections in the release notes?</
       <when>After creating patch notes, before updating combined notes</when>
       <purpose>Ensure patch notes are final before propagating</purpose>
       <critical>NEVER update combined notes until explicit confirmation</critical>
-      <template><![CDATA[
+      <template>
 <ask_followup_question>
 <question>I've created the release notes for v[VERSION]. The file includes:
 
@@ -100,13 +104,13 @@ Would you like to review before I update the combined v[X.Y] notes?</question>
 <suggest>Change the emphasis on certain features</suggest>
 </follow_up>
 </ask_followup_question>
-      ]]></template>
+      </template>
     </point>
 
     <point name="documentation_needs">
       <when>After identifying documentation flags</when>
       <purpose>Confirm documentation update requirements</purpose>
-      <template><![CDATA[
+      <template>
 <ask_followup_question>
 <question>I've identified [COUNT] items that need documentation updates:
 
@@ -120,13 +124,13 @@ Should I create a documentation update task after completing the release notes?<
 <suggest>Let me review the specific items first</suggest>
 </follow_up>
 </ask_followup_question>
-      ]]></template>
+      </template>
     </point>
 
     <point name="final_review">
       <when>After all updates complete</when>
       <purpose>Final confirmation before PR creation</purpose>
-      <template><![CDATA[
+      <template>
 <ask_followup_question>
 <question>I've completed all updates for v[VERSION]:
 
@@ -143,7 +147,7 @@ Would you like to create a PR or make any final adjustments?</question>
 <suggest>Create documentation update task first</suggest>
 </follow_up>
 </ask_followup_question>
-      ]]></template>
+      </template>
     </point>
   </confirmation_points>
 
@@ -154,7 +158,7 @@ Would you like to create a PR or make any final adjustments?</question>
       <step>Detect missing versions from changelog</step>
       <step>Present found versions</step>
     </workflow>
-    <template><![CDATA[
+    <template>
 <ask_followup_question>
 <question>I found [COUNT] versions in the changelog that don't have release notes:
 [List versions]
@@ -167,7 +171,7 @@ Which would you like to process?</question>
 <suggest>Show changelog entries first</suggest>
 </follow_up>
 </ask_followup_question>
-    ]]></template>
+    </template>
   </latest_version_interaction>
 
   <adjustment_handling>
@@ -211,7 +215,7 @@ Which would you like to process?</question>
         <item>Verify actual count of changes</item>
         <item>Maintain markdown code block and hyphen bullets</item>
       </validation>
-      <template><![CDATA[
+      <template>
 <ask_followup_question>
 <question>The Discord post is long. Compress remaining sections into a single "More Changes" paragraph?</question>
 <follow_up>
@@ -219,7 +223,7 @@ Which would you like to process?</question>
 <suggest>No, keep full details</suggest>
 </follow_up>
 </ask_followup_question>
-      ]]></template>
+      </template>
     </compression_workflow>
   </discord_format_interaction>
 
@@ -256,7 +260,7 @@ Which would you like to process?</question>
       <item>Footer links as hyphen bullets to each version's docs page</item>
       <item>Wrap entire output in ```markdown code block</item>
     </formatting_checklist>
-    <template><![CDATA[
+    <template>
 <ask_followup_question>
 <question>If the combined post is long, should I compress minor sections into a single "More Changes" paragraph?</question>
 <follow_up>
@@ -264,7 +268,7 @@ Which would you like to process?</question>
 <suggest>No, keep full details</suggest>
 </follow_up>
 </ask_followup_question>
-    ]]></template>
+    </template>
   </discord_combined_interaction>
 
   <best_practices>


### PR DESCRIPTION
This PR updates the Release Notes Writer rules XML files in .roo/rules-release-notes-writer.&#10;&#10;Changes:&#10;- Update 1_main_workflow.xml&#10;- Update 2_content_standards.xml&#10;- Update 3_user_interactions.xml&#10;&#10;Generated by Roo automation.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update XML formatting in release notes writer rules by removing CDATA sections for consistency.
> 
>   - **Files Updated**:
>     - `.roo/rules-release-notes-writer/1_main_workflow.xml`: Removed CDATA sections from `<command>`, `<message_template>`, `<todos_template>`, `<output_format>`, and `<implementation>` elements.
>     - `.roo/rules-release-notes-writer/2_content_standards.xml`: Removed CDATA sections from `<format>`, `<template>`, and `<format_single>` elements.
>     - `.roo/rules-release-notes-writer/3_user_interactions.xml`: Removed CDATA sections from `<template>`, `<template_inclusion_policy>`, and `<template_per_pr_review>` elements.
>   - **Behavior**:
>     - Ensures XML formatting consistency by removing CDATA sections across multiple XML files.
>     - No functional changes to the logic or processing of release notes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code-Docs&utm_source=github&utm_medium=referral)<sup> for a8b21ddbbfb58254cca8cb7eabdc110441e4e38e. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->