### PR TITLE
docs: release notes v3.30.1 + combined updates

### DIFF
--- a/docs/update-notes/index.md
+++ b/docs/update-notes/index.md
@@ -19,6 +19,7 @@ image: /img/social-share.jpg
  
 ### Version 3.30
 
+*   [3.30.1](/update-notes/v3.30.1) (2025-11-04)
 *   [3.30](/update-notes/v3.30) (2025-11-03)
 *   [3.30.0](/update-notes/v3.30.0) (2025-11-03)
 

--- a/docs/update-notes/v3.30.1.mdx
+++ b/docs/update-notes/v3.30.1.mdx
@@ -1,0 +1,20 @@
+---
+description: Roo Code 3.30.1 fixes an embedding dimension mismatch and reverts a problematic cancel/resume change to restore stability.
+keywords:
+  - roo code 3.30.1
+  - bug fixes
+  - embeddings
+  - OpenRouter
+  - Mistral
+  - UI flicker
+image: /img/social-share.jpg
+---
+# Roo Code 3.30.1 Release Notes (2025-11-04)
+
+This patch improves reliability by fixing an embedding dimension mismatch and restoring stable cancel/resume behavior.
+
+
+## Bug Fixes
+
+* Correct OpenRouter Mistral embedding dimension to 1536 to prevent vector size errors; existing Qdrant collections are recreated with the correct size for consistent similarity search ([#9028](https://github.com/RooCodeInc/Roo-Code/pull/9028))
+* Revert recent cancel/resume change that caused UI flicker and unreliable resumption, restoring the previous stable behavior while a safer fix is prepared ([#9032](https://github.com/RooCodeInc/Roo-Code/pull/9032))

--- a/docs/update-notes/v3.30.mdx
+++ b/docs/update-notes/v3.30.mdx
@@ -32,6 +32,8 @@ OpenRouter currently supports 7 embedding models, including the top‑ranking Qw
 * Cancel during streaming no longer causes flicker; you can resume in place, input stays enabled, and the spinner stops deterministically ([#8986](https://github.com/RooCodeInc/Roo-Code/pull/8986))
 * Remove newline-only reasoning blocks from OpenAI-compatible responses for cleaner output and logs ([#8990](https://github.com/RooCodeInc/Roo-Code/pull/8990))
 * "Disable Terminal Shell Integration" now links to the correct documentation section ([#8997](https://github.com/RooCodeInc/Roo-Code/pull/8997))
+* Correct OpenRouter Mistral embedding dimension to 1536 to prevent vector size errors; existing Qdrant collections are recreated with the correct size for consistent similarity search ([#9028](https://github.com/RooCodeInc/Roo-Code/pull/9028))
+* Revert the recent cancel/resume change that caused UI flicker and unreliable resumption, restoring the previous stable behavior ([#9032](https://github.com/RooCodeInc/Roo-Code/pull/9032))
 
 ## Misc Improvements
 

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -223,6 +223,7 @@ const sidebars: SidebarsConfig = {
           label: '3.30',
           items: [
             { type: 'doc', id: 'update-notes/v3.30', label: '3.30 Combined' },
+            { type: 'doc', id: 'update-notes/v3.30.1', label: '3.30.1' },
             { type: 'doc', id: 'update-notes/v3.30.0', label: '3.30.0' },
           ],
         },


### PR DESCRIPTION
docs: release notes v3.30.1 + combined updates

Summary
- Add v3.30.1 patch notes (default social image; inline hero removed)
- Update Update Notes index and sidebar
- Append two bug fixes to combined v3.30

Details
- New file: docs/update-notes/v3.30.1.mdx (2025-11-04)
- Index: add 3.30.1 under “Version 3.30”
- Sidebar: add entry 'update-notes/v3.30.1' under 3.30
- Combined: add bug fixes for:
  • Correct OpenRouter Mistral embedding dimension to 1536 to prevent vector size errors (PR #9028)
  • Revert cancel/resume change to address UI flicker and unreliable resumption (PR #9032)

Changelog alignment
- Included: #9028, #9032
- Excluded: #9033 (changeset), #9034 (version bump)

Release date: 2025-11-04

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add v3.30.1 release notes and update documentation index and sidebar for new patch release.
> 
>   - **Release Notes**:
>     - Add `v3.30.1.mdx` for patch notes, detailing fixes for embedding dimension mismatch and cancel/resume behavior.
>     - Append bug fixes to `v3.30.mdx` for embedding dimension and cancel/resume issues.
>   - **Documentation Index**:
>     - Update `index.md` to include v3.30.1 under "Version 3.30".
>   - **Sidebar**:
>     - Add `update-notes/v3.30.1` entry to `sidebars.ts` under 3.30 category.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code-Docs&utm_source=github&utm_medium=referral)<sup> for f93e998460954337488fd9fd23b3cd354e0c925d. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->