### PR TITLE
Fix China Mainland URL for MiniMax provider

### DIFF
--- a/docs/providers/minimax.md
+++ b/docs/providers/minimax.md
@@ -22,7 +22,7 @@ MiniMax is an OpenAI‑compatible provider. Pick the correct region endpoint, ad
 2. Select Provider: “MiniMax”.
 3. Choose Base URL (region):
    - International: https://api.minimax.io/v1
-   - China (Mainland): https://api.minimax.com/v1
+   - China (Mainland): https://api.minimaxi.com/v1
 4. Enter your API key in “MiniMax API Key”.
 5. Select a model from the dropdown.
 6. Optional: adjust Temperature and Max Output Tokens in model settings.


### PR DESCRIPTION
My mistake, sorry, I thought minimaxi.com is not a valid url, but it turns out to be correct, checked the minimax documentation at https://platform.minimax.io/docs/guides/text-ai-coding-tools