### PR TITLE
docs: add v3.34.1 and combined v3.34 release notes

### DIFF
--- a/docs/update-notes/index.md
+++ b/docs/update-notes/index.md
@@ -19,6 +19,8 @@ image: /img/social-share.jpg
   
 ### Version 3.34
 
+*   [3.34](/update-notes/v3.34) (Combined)
+*   [3.34.1](/update-notes/v3.34.1) (2025-11-23)
 *   [3.34.0](/update-notes/v3.34.0) (2025-11-21)
 
 ### Version 3.33

--- a/docs/update-notes/v3.34.1.mdx
+++ b/docs/update-notes/v3.34.1.mdx
@@ -1,0 +1,24 @@
+---
+description: This patch release lets eval jobs run on Roo Code Cloud models, clarifies image generation prompts, cleans up todo list updates, and fixes duplicate cloud message sync.
+keywords:
+  - roo code 3.34.1
+  - evals roo code cloud
+  - image generation ui
+  - todo list ui
+  - cloud sync bug fix
+image: /img/social-share.jpg
+---
+
+# Roo Code 3.34.1 Release Notes (2025-11-23)
+
+This patch release lets evaluation jobs run on Roo Code Cloud models, makes image generation prompts easier to read, cleans up todo list updates, and prevents duplicate cloud-synced messages.
+
+## Bug Fixes
+
+* **Single todo list in updates**: Removed a redundant todo list block from chat updates so you only see one clean, focused list when the updateTodoList tool runs ([#9517](https://github.com/RooCodeInc/Roo-Code/pull/9517), [#9522](https://github.com/RooCodeInc/Roo-Code/pull/9522)).
+* **Cloud message deduplication**: Fixed cloud message syncing so duplicate copies of the same reasoning or assistant message are no longer re-synced, keeping task histories cleaner and less confusing ([#9518](https://github.com/RooCodeInc/Roo-Code/pull/9518), [#9522](https://github.com/RooCodeInc/Roo-Code/pull/9522)).
+
+## QOL Improvements
+
+* **Clearer image generation prompts**: The full prompt and path for image generation now appear directly in the chat UI with clearer spacing and typography, making it easier to inspect, debug, and reuse prompts ([#9505](https://github.com/RooCodeInc/Roo-Code/pull/9505), [#9522](https://github.com/RooCodeInc/Roo-Code/pull/9522)).
+* **Eval jobs on Roo Code Cloud**: You can now run evaluation jobs directly on Roo Code Cloud models, reusing the same managed models and job tokens as regular cloud runs ([#9492](https://github.com/RooCodeInc/Roo-Code/pull/9492), [#9522](https://github.com/RooCodeInc/Roo-Code/pull/9522)).

--- a/docs/update-notes/v3.34.mdx
+++ b/docs/update-notes/v3.34.mdx
@@ -1,0 +1,52 @@
+---
+description: Combined notes for Roo Code 3.34, including Browser Use 2.0, the Baseten provider, OpenAI-compatible improvements, Roo Code Cloud eval jobs, image generation UI tweaks, todo list cleanup, and cloud sync fixes.
+keywords:
+  - roo code 3.34
+  - browser use 2.0
+  - baseten provider
+  - openai compatible
+  - evals roo code cloud
+  - image generation ui
+  - todo list ui
+  - cloud sync bug fix
+image: /img/v3.34.0/v3.34.0.png
+---
+
+# Roo Code 3.34 Release Notes (2025-11-21)
+
+Roo Code 3.34 combines Browser Use 2.0, the Baseten provider, OpenAI-compatible improvements, and refined onboarding and native tool descriptions with a patch that adds Roo Code Cloud eval support, clearer image generation prompts, todo list cleanup, and cloud sync fixes.
+
+<img src="/img/v3.34.0/v3.34.0.png" alt="Roo Code v3.34 Release" width="600" />
+
+## Browser Use 2.0
+
+Browser Use now supports a more capable "2.0" experience ([#8941](https://github.com/RooCodeInc/Roo-Code/pull/8941)):
+
+- **Richer browser interaction**: Enables more advanced navigation and interaction patterns so Roo can better follow multi-step web workflows.
+- **More reliable automation**: Improves stability for sequences of clicks, typing, and scrolling, reducing the chance of flaky browser runs.
+- **Better fit for complex sites**: Makes it easier to work with modern web apps that require multiple steps or stateful interactions.
+
+> **📚 Documentation**: See [Browser Use](/features/browser-use) for details on how to enable and use browser workflows. Note: We have not yet updated these docs with images and a video of the new experiance.
+
+## QOL Improvements
+
+- **Provider-oriented welcome screen**: Added a provider-focused welcome screen so new users can more quickly choose and configure a working model setup ([#9484](https://github.com/RooCodeInc/Roo-Code/pull/9484)).
+- **Pinned Roo provider**: Pinned the Roo provider to the top of the provider list so it is easier to discover and select ([#9485](https://github.com/RooCodeInc/Roo-Code/pull/9485)).
+- **Clearer native tool descriptions**: Enhanced built-in tool descriptions with examples and clarifications so Roo can choose the right tools and use them more accurately ([#9486](https://github.com/RooCodeInc/Roo-Code/pull/9486)).
+- **Clearer image generation prompts**: The full prompt and path for image generation now appear directly in the chat UI with clearer spacing and typography, making it easier to inspect, debug, and reuse prompts ([#9505](https://github.com/RooCodeInc/Roo-Code/pull/9505), [#9522](https://github.com/RooCodeInc/Roo-Code/pull/9522)).
+- **Eval jobs on Roo Code Cloud**: You can now run evaluation jobs directly on Roo Code Cloud models, reusing the same managed models and job tokens as regular cloud runs ([#9492](https://github.com/RooCodeInc/Roo-Code/pull/9492), [#9522](https://github.com/RooCodeInc/Roo-Code/pull/9522)).
+
+## Bug Fixes
+
+- **Streaming cancel responsiveness**: Fixed the cancel button so it responds immediately during streaming, making it easier to stop long or unwanted runs ([#9448](https://github.com/RooCodeInc/Roo-Code/pull/9448)).
+- **apply_diff performance regression**: Resolved a recent performance regression in `apply_diff`, restoring fast patch application on larger edits ([#9474](https://github.com/RooCodeInc/Roo-Code/pull/9474)).
+- **Model cache refresh**: Implemented cache refreshing to avoid using stale disk-cached models, ensuring configuration updates are picked up correctly ([#9478](https://github.com/RooCodeInc/Roo-Code/pull/9478)).
+- **Tool call fallbacks**: Added a fallback to always yield tool calls regardless of `finish_reason`, preventing cases where valid tool calls were dropped ([#9476](https://github.com/RooCodeInc/Roo-Code/pull/9476)).
+- **Single todo list in updates**: Removed a redundant todo list block from chat updates so you only see one clean, focused list when the updateTodoList tool runs ([#9517](https://github.com/RooCodeInc/Roo-Code/pull/9517), [#9522](https://github.com/RooCodeInc/Roo-Code/pull/9522)).
+- **Cloud message deduplication**: Fixed cloud message syncing so duplicate copies of the same reasoning or assistant message are no longer re-synced, keeping task histories cleaner and less confusing ([#9518](https://github.com/RooCodeInc/Roo-Code/pull/9518), [#9522](https://github.com/RooCodeInc/Roo-Code/pull/9522)).
+
+## Provider Updates
+
+- **Baseten provider**: Added Baseten as a new AI provider, giving you another option for hosted models and deployments ([#9461](https://github.com/RooCodeInc/Roo-Code/pull/9461)).
+- **OpenAI-compatible improvements**: Improved the base OpenAI-compatible provider configuration and error handling so more OpenAI-style endpoints work smoothly without special tweaks ([#9462](https://github.com/RooCodeInc/Roo-Code/pull/9462)).
+- **OpenRouter capabilities**: Improved copying of model-level capabilities onto OpenRouter endpoint models so routing respects each model's real abilities ([#9483](https://github.com/RooCodeInc/Roo-Code/pull/9483)).

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -222,6 +222,8 @@ const sidebars: SidebarsConfig = {
           type: 'category',
           label: '3.34',
           items: [
+            { type: 'doc', id: 'update-notes/v3.34', label: '3.34 Combined' },
+            { type: 'doc', id: 'update-notes/v3.34.1', label: '3.34.1' },
             { type: 'doc', id: 'update-notes/v3.34.0', label: '3.34.0' },
           ],
         },


### PR DESCRIPTION
Adds patch release notes for v3.34.1 plus combined v3.34 notes, and wires them into the update-notes index and sidebar.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds v3.34.1 and combined v3.34 release notes, updating the documentation index and sidebar.
> 
>   - **Release Notes**:
>     - Adds `v3.34.1.mdx` for patch release notes, detailing eval jobs on Roo Code Cloud, image generation prompt improvements, todo list cleanup, and cloud sync fixes.
>     - Adds `v3.34.mdx` for combined v3.34 release notes, including Browser Use 2.0, Baseten provider, and OpenAI-compatible improvements.
>   - **Documentation Index**:
>     - Updates `index.md` to include links to `v3.34` (Combined) and `v3.34.1` release notes.
>   - **Sidebar**:
>     - Updates `sidebars.ts` to include `v3.34` and `v3.34.1` in the update notes section.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code-Docs&utm_source=github&utm_medium=referral)<sup> for c88d4e9658cbec45c747f090bbc9bc1cc2b2ab73. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->