### PR TITLE
docs: add release notes for v3.35.3 and v3.35.4

### DIFF
--- a/docs/update-notes/index.md
+++ b/docs/update-notes/index.md
@@ -20,6 +20,8 @@ image: /img/social-share.jpg
 ### Version 3.35
 
 *   [3.35](/update-notes/v3.35) (Combined)
+*   [3.35.4](/update-notes/v3.35.4) (2025-12-02)
+*   [3.35.3](/update-notes/v3.35.3) (2025-12-02)
 *   [3.35.2](/update-notes/v3.35.2) (2025-12-01)
 *   [3.35.1](/update-notes/v3.35.1) (2025-12-01)
 *   [3.35.0](/update-notes/v3.35.0) (2025-12-01)

--- a/docs/update-notes/v3.35.3.mdx
+++ b/docs/update-notes/v3.35.3.mdx
@@ -1,0 +1,21 @@
+---
+description: Roo Code 3.35.3 features an improved welcome view and stealth model privacy for API configurations.
+keywords:
+  - roo code 3.35.3
+  - welcome view
+  - stealth models
+  - privacy
+image: /img/social-share.jpg
+---
+
+# Roo Code 3.35.3 Release Notes (2025-12-02)
+
+This release improves the onboarding experience with a simplified welcome view and adds stealth model support for API providers.
+
+## QOL Improvements
+
+* **New Welcome View**: Simplified welcome view with consolidated components for a cleaner, more consistent onboarding experience ([#9741](https://github.com/RooCodeInc/Roo-Code/pull/9741))
+
+## Misc Improvements
+
+* **Stealth Model Privacy**: Models tagged with "stealth" in the Roo API now receive vendor confidentiality instructions in their system prompt, enabling white-label or anonymous model experiences ([#9742](https://github.com/RooCodeInc/Roo-Code/pull/9742))

--- a/docs/update-notes/v3.35.4.mdx
+++ b/docs/update-notes/v3.35.4.mdx
@@ -1,0 +1,25 @@
+---
+description: Roo Code 3.35.4 fixes tool call handling, simplifies the write_to_file tool, and updates z.ai provider settings.
+keywords:
+  - roo code 3.35.4
+  - bug fixes
+  - write_to_file
+  - z.ai
+image: /img/social-share.jpg
+---
+
+# Roo Code 3.35.4 Release Notes (2025-12-02)
+
+This release fixes a tool call handling regression, simplifies the write_to_file tool, and corrects z.ai provider UI.
+
+## QOL Improvements
+
+* **Simplified write_to_file Tool**: The `line_count` parameter has been removed from the write_to_file tool, making tool calls cleaner and reducing potential errors from incorrect line counts ([#9667](https://github.com/RooCodeInc/Roo-Code/pull/9667))
+
+## Bug Fixes
+
+* **Malformed Tool Call Fix**: Fixed a regression where malformed native tool calls would cause Roo Code to hang indefinitely. Tool calls now proceed to validation which catches and reports the missing parameters properly ([#9758](https://github.com/RooCodeInc/Roo-Code/pull/9758))
+
+## Provider Updates
+
+* **z.ai GLM Model Fix**: Removed misleading reasoning toggle UI for GLM-4.5 and GLM-4.6 models on z.ai provider, as these models don't support think/reasoning data for coding agents ([#9752](https://github.com/RooCodeInc/Roo-Code/pull/9752))

--- a/docs/update-notes/v3.35.mdx
+++ b/docs/update-notes/v3.35.mdx
@@ -44,12 +44,15 @@ Native tool calling support has been expanded to 15+ providers:
 * **Tool Format in Environment Details**: Models now receive tool format information, improving behavior when switching between XML and native tools ([#9661](https://github.com/RooCodeInc/Roo-Code/pull/9661))
 * **Debug Buttons**: View API and UI history with new debug buttons (requires `roo-cline.debug: true`) ([#9684](https://github.com/RooCodeInc/Roo-Code/pull/9684))
 * **Grok Code Fast Default**: Native tools now default for xai/grok-code-fast-1 ([#9717](https://github.com/RooCodeInc/Roo-Code/pull/9717))
+* **New Welcome View**: Simplified welcome view with consolidated components for a cleaner, more consistent onboarding experience ([#9741](https://github.com/RooCodeInc/Roo-Code/pull/9741))
+* **Simplified write_to_file Tool**: The `line_count` parameter has been removed from the write_to_file tool, making tool calls cleaner and reducing potential errors from incorrect line counts ([#9667](https://github.com/RooCodeInc/Roo-Code/pull/9667))
 
 ## Bug Fixes
 
 * **Parallel Tool Calls Fix**: Preserve tool_use blocks in summary during context condensation, fixing 400 errors with Anthropic's parallel tool calls feature (thanks SilentFlower!) ([#9714](https://github.com/RooCodeInc/Roo-Code/pull/9714))
 * **Navigation Button Wrapping**: Prevent navigation buttons from wrapping on smaller screens ([#9721](https://github.com/RooCodeInc/Roo-Code/pull/9721))
 * **Task Delegation Tool Flush**: Fixes 400 errors that occurred when using native tool protocol with parallel tool calls (e.g., `update_todo_list` + `new_task`). Pending tool results are now properly flushed before task delegation ([#9726](https://github.com/RooCodeInc/Roo-Code/pull/9726))
+* **Malformed Tool Call Fix**: Fixed a regression where malformed native tool calls would cause Roo Code to hang indefinitely. Tool calls now proceed to validation which catches and reports the missing parameters properly ([#9758](https://github.com/RooCodeInc/Roo-Code/pull/9758))
 
 ## Misc Improvements
 
@@ -57,6 +60,7 @@ Native tool calling support has been expanded to 15+ providers:
 * **apply_patch Tool**: New native tool for file editing using simplified diff format with fuzzy matching and file rename support ([#9663](https://github.com/RooCodeInc/Roo-Code/pull/9663))
 * **search_and_replace Tool**: Batch text replacements with partial matching and error recovery ([#9549](https://github.com/RooCodeInc/Roo-Code/pull/9549))
 * **Better IPC Error Logging**: Error logs now display detailed structured data instead of unhelpful `[object Object]` messages, making debugging extension issues easier ([#9727](https://github.com/RooCodeInc/Roo-Code/pull/9727))
+* **Stealth Model Privacy**: Models tagged with "stealth" in the Roo API now receive vendor confidentiality instructions in their system prompt, enabling white-label or anonymous model experiences ([#9742](https://github.com/RooCodeInc/Roo-Code/pull/9742))
 
 ## Provider Updates
 
@@ -64,3 +68,4 @@ Native tool calling support has been expanded to 15+ providers:
 * **Roo Provider Native Tools**: Models with the `default-native-tools` tag automatically use native tool calling by default ([#9735](https://github.com/RooCodeInc/Roo-Code/pull/9735))
 * **LiteLLM Native Tool Support**: All LiteLLM models now assume native tool support by default, improving tool compatibility ([#9736](https://github.com/RooCodeInc/Roo-Code/pull/9736))
 * **App Version Tracking**: The Roo provider now sends app version information with API requests for improved request tracking ([#9730](https://github.com/RooCodeInc/Roo-Code/pull/9730))
+* **z.ai GLM Model Fix**: Removed misleading reasoning toggle UI for GLM-4.5 and GLM-4.6 models on z.ai provider, as these models don't support think/reasoning data for coding agents ([#9752](https://github.com/RooCodeInc/Roo-Code/pull/9752))

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -224,6 +224,8 @@ const sidebars: SidebarsConfig = {
           label: '3.35',
           items: [
             { type: 'doc', id: 'update-notes/v3.35', label: '3.35 Combined' },
+            { type: 'doc', id: 'update-notes/v3.35.4', label: '3.35.4' },
+            { type: 'doc', id: 'update-notes/v3.35.3', label: '3.35.3' },
             { type: 'doc', id: 'update-notes/v3.35.2', label: '3.35.2' },
             { type: 'doc', id: 'update-notes/v3.35.1', label: '3.35.1' },
             { type: 'doc', id: 'update-notes/v3.35.0', label: '3.35.0' },


### PR DESCRIPTION
## Summary
Add release notes for Roo Code v3.35.3 and v3.35.4.

### v3.35.3 (2025-12-02)
- **QOL**: New welcome view with consolidated components (#9741)
- **Misc**: Stealth model privacy for API providers (#9742)

### v3.35.4 (2025-12-02)
- **QOL**: Simplified write_to_file tool - removed line_count parameter (#9667)
- **Bug Fix**: Malformed tool calls no longer cause hanging (#9758)
- **Provider Update**: z.ai GLM-4.5/4.6 reasoning toggle fix (#9752)

## Files Changed
- Created `docs/update-notes/v3.35.3.mdx`
- Created `docs/update-notes/v3.35.4.mdx`
- Updated `docs/update-notes/v3.35.mdx` (combined notes)
- Updated `docs/update-notes/index.md`
- Updated `sidebars.ts`
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add release notes for Roo Code versions 3.35.3 and 3.35.4, updating documentation and sidebar.
> 
>   - **Release Notes**:
>     - Added `v3.35.3.mdx` and `v3.35.4.mdx` for Roo Code versions 3.35.3 and 3.35.4.
>     - Updated `v3.35.mdx` to include notes from 3.35.3 and 3.35.4.
>   - **Documentation Index**:
>     - Updated `index.md` to list versions 3.35.3 and 3.35.4.
>   - **Sidebar**:
>     - Updated `sidebars.ts` to include 3.35.3 and 3.35.4 under version 3.35.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code-Docs&utm_source=github&utm_medium=referral)<sup> for dfcb885e945b1aff4dca14643a62206ea67806e7. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->