### PR TITLE
docs: add release notes for v3.35.5

### DIFF
--- a/docs/update-notes/index.md
+++ b/docs/update-notes/index.md
@@ -20,6 +20,7 @@ image: /img/social-share.jpg
 ### Version 3.35
 
 *   [3.35](/update-notes/v3.35) (Combined)
+*   [3.35.5](/update-notes/v3.35.5) (2025-12-03)
 *   [3.35.4](/update-notes/v3.35.4) (2025-12-02)
 *   [3.35.3](/update-notes/v3.35.3) (2025-12-02)
 *   [3.35.2](/update-notes/v3.35.2) (2025-12-01)

--- a/docs/update-notes/v3.35.5.mdx
+++ b/docs/update-notes/v3.35.5.mdx
@@ -1,0 +1,26 @@
+---
+description: Adds OpenRouter embedding provider routing, updates CloudView UI, and improves provider compatibility.
+keywords:
+  - roo code 3.35.5
+  - openrouter embeddings
+  - provider routing
+  - cloudview
+image: /img/social-share.jpg
+---
+
+# Roo Code v3.35.5 Release Notes (2025-12-03)
+
+This release adds provider routing selection for OpenRouter embeddings, updates the CloudView interface, and improves provider compatibility.
+
+## Features
+
+* **OpenRouter Embeddings Provider Routing**: Select specific routing providers for OpenRouter embeddings in code indexing settings, enabling cost optimization since providers can vary by 4-5x in price for the same embedding model (thanks SannidhyaSah!) ([#9693](https://github.com/RooCodeInc/Roo-Code/pull/9693))
+
+## QOL Improvements
+
+* **CloudView Interface Updates**: Cleaner UI with refreshed marketing copy, updated button styling with rounded corners for a more modern look ([#9776](https://github.com/RooCodeInc/Roo-Code/pull/9776))
+
+## Provider Updates
+
+* **Roo Provider Tool Compatibility**: Improved tool conversion for OpenAI-compatible API endpoints, ensuring tools work correctly with OpenAI-style request formats ([#9769](https://github.com/RooCodeInc/Roo-Code/pull/9769))
+* **MiniMax M2 Free Tier Default**: MiniMax M2 model now defaults to the free tier when using OpenRouter ([#9778](https://github.com/RooCodeInc/Roo-Code/pull/9778))

--- a/docs/update-notes/v3.35.mdx
+++ b/docs/update-notes/v3.35.mdx
@@ -46,6 +46,8 @@ Native tool calling support has been expanded to 15+ providers:
 * **Grok Code Fast Default**: Native tools now default for xai/grok-code-fast-1 ([#9717](https://github.com/RooCodeInc/Roo-Code/pull/9717))
 * **New Welcome View**: Simplified welcome view with consolidated components for a cleaner, more consistent onboarding experience ([#9741](https://github.com/RooCodeInc/Roo-Code/pull/9741))
 * **Simplified write_to_file Tool**: The `line_count` parameter has been removed from the write_to_file tool, making tool calls cleaner and reducing potential errors from incorrect line counts ([#9667](https://github.com/RooCodeInc/Roo-Code/pull/9667))
+* **OpenRouter Embeddings Provider Routing**: Select specific routing providers for OpenRouter embeddings in code indexing settings, enabling cost optimization since providers can vary by 4-5x in price for the same embedding model (thanks SannidhyaSah!) ([#9693](https://github.com/RooCodeInc/Roo-Code/pull/9693))
+* **CloudView Interface Updates**: Cleaner UI with refreshed marketing copy, updated button styling with rounded corners for a more modern look ([#9776](https://github.com/RooCodeInc/Roo-Code/pull/9776))
 
 ## Bug Fixes
 
@@ -69,3 +71,5 @@ Native tool calling support has been expanded to 15+ providers:
 * **LiteLLM Native Tool Support**: All LiteLLM models now assume native tool support by default, improving tool compatibility ([#9736](https://github.com/RooCodeInc/Roo-Code/pull/9736))
 * **App Version Tracking**: The Roo provider now sends app version information with API requests for improved request tracking ([#9730](https://github.com/RooCodeInc/Roo-Code/pull/9730))
 * **z.ai GLM Model Fix**: Removed misleading reasoning toggle UI for GLM-4.5 and GLM-4.6 models on z.ai provider, as these models don't support think/reasoning data for coding agents ([#9752](https://github.com/RooCodeInc/Roo-Code/pull/9752))
+* **Roo Provider Tool Compatibility**: Improved tool conversion for OpenAI-compatible API endpoints, ensuring tools work correctly with OpenAI-style request formats ([#9769](https://github.com/RooCodeInc/Roo-Code/pull/9769))
+* **MiniMax M2 Free Tier Default**: MiniMax M2 model now defaults to the free tier when using OpenRouter ([#9778](https://github.com/RooCodeInc/Roo-Code/pull/9778))

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -224,6 +224,7 @@ const sidebars: SidebarsConfig = {
           label: '3.35',
           items: [
             { type: 'doc', id: 'update-notes/v3.35', label: '3.35 Combined' },
+            { type: 'doc', id: 'update-notes/v3.35.5', label: '3.35.5' },
             { type: 'doc', id: 'update-notes/v3.35.4', label: '3.35.4' },
             { type: 'doc', id: 'update-notes/v3.35.3', label: '3.35.3' },
             { type: 'doc', id: 'update-notes/v3.35.2', label: '3.35.2' },


### PR DESCRIPTION
## Summary

Adds release notes for Roo Code v3.35.5.

## Changes Included (4 PRs)

- **OpenRouter Embeddings Provider Routing** (#9693) - Select specific routing providers for OpenRouter embeddings, enabling cost optimization
- **CloudView Interface Updates** (#9776) - Cleaner UI with refreshed marketing copy and modern button styling
- **Roo Provider Tool Compatibility** (#9769) - Improved tool conversion for OpenAI-compatible API endpoints
- **MiniMax M2 Free Tier Default** (#9778) - MiniMax M2 model now defaults to the free tier via OpenRouter

## Files Changed

- `docs/update-notes/v3.35.5.mdx` - New release notes
- `docs/update-notes/index.md` - Added v3.35.5 entry
- `sidebars.ts` - Added v3.35.5 to navigation
- `docs/update-notes/v3.35.mdx` - Updated combined notes with v3.35.5 changes
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds release notes for v3.35.5, detailing new features and improvements, and updates documentation navigation.
> 
>   - **Release Notes**:
>     - Adds `v3.35.5.mdx` with details on OpenRouter embeddings provider routing, CloudView UI updates, and provider compatibility improvements.
>     - Updates `v3.35.mdx` to include v3.35.5 changes.
>   - **Documentation Index**:
>     - Updates `index.md` to list v3.35.5.
>     - Updates `sidebars.ts` to include v3.35.5 in navigation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code-Docs&utm_source=github&utm_medium=referral)<sup> for 3fd49ea1c722e86fa8b5695ef04d6366cfb7c8a8. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->