### PR TITLE
docs: codebase-indexing: Bind qdrant to 127.0.0.1 for security

### DIFF
--- a/docs/features/codebase-indexing.mdx
+++ b/docs/features/codebase-indexing.mdx
@@ -83,7 +83,7 @@ Using Docker:
 docker run -d \
   --name qdrant \
   --restart unless-stopped \
-  -p 6333:6333 \
+  -p 127.0.0.1:6333:6333 \
   -v qdrant_data:/qdrant/storage \
   qdrant/qdrant
 ```
@@ -94,7 +94,7 @@ services:
   qdrant:
     image: qdrant/qdrant
     ports:
-      - "6333:6333"
+      - "127.0.0.1:6333:6333"
     volumes:
       - qdrant_storage:/qdrant/storage
 volumes:


### PR DESCRIPTION
As explained on

  https://qdrant.tech/documentation/guides/security/#network-bind

it is unwise to make qdrant listen on the public network interface because then anybody on the local network (or Internet for server) can abuse it.

---

Note I have not tested this change, but it should work.

<!-- roo-code-cloud-preview-start -->
[Interactively review PR in Roo Code Cloud](https://app.roocode.com/preview?repo=RooCodeInc%2FRoo-Code-Docs&sha=f56d100ca036a6ad33a8459571e0dd864f4492be&pr=548&branch=patch-1)
<!-- roo-code-cloud-preview-end -->