### PR TITLE
Enhance troubleshooting section for Qdrant connection errors

### DIFF
--- a/docs/features/codebase-indexing.mdx
+++ b/docs/features/codebase-indexing.mdx
@@ -285,6 +285,12 @@ Use natural language descriptions:
 - Ensure the key has necessary permissions
 - For Ollama, verify the service is running
 
+**"Internal Server Error" when connecting to Qdrant**
+- Potential causes include Roo Code's Qdrant client being incompatible with newer Qdrant server versions
+- Check the [Roo Code releases](https://github.com/RooCodeInc/Roo-Code/releases) 
+  for the supported Qdrant version, or pin your Docker image to a specific version 
+  (e.g., `qdrant/qdrant:v1.13.6`) rather than using `latest` to fix this version of the issue
+
 ### API Key Format Errors (“ByteString conversion”)
 
 - Symptom: Error mentions "ByteString conversion" during indexing or when saving settings

--- a/docs/features/codebase-indexing.mdx
+++ b/docs/features/codebase-indexing.mdx
@@ -287,9 +287,10 @@ Use natural language descriptions:
 
 **"Internal Server Error" when connecting to Qdrant**
 - Potential causes include Roo Code's Qdrant client being incompatible with newer Qdrant server versions
-- Check the [Roo Code releases](https://github.com/RooCodeInc/Roo-Code/releases) 
-  for the supported Qdrant version, or pin your Docker image to a specific version 
+- Check your editor's dev tools console logs for the supported Qdrant version, and pin your Docker image to a specific version 
   (e.g., `qdrant/qdrant:v1.13.6`) rather than using `latest` to fix this version of the issue
+  - For VS Code: Open Command Palette with Ctrl+Shift+P (Windows/Linux) or Cmd+Shift+P (Mac).
+  - Type `Developer: Toggle Developer Tools` and select command from list. 
 
 ### API Key Format Errors (“ByteString conversion”)
 


### PR DESCRIPTION
Added troubleshooting tips for (one potential cause of) 'Internal Server Error' when connecting to Qdrant, including version compatibility and Docker image pinning.

Related to RooCodeInc/Roo-Code#11885

<!-- roo-code-cloud-preview-start -->
[Interactively review PR in Roo Code Cloud](https://app.roocode.com/preview?repo=RooCodeInc%2FRoo-Code-Docs&sha=d983408ba100e65745f541cba612188ec5cb54bf&pr=549&branch=docs%2Fadd-qdrant-version-drift-fix-section)
<!-- roo-code-cloud-preview-end -->