### PR TITLE
docs: add QVAC provider setup guide

### DIFF
--- a/docs/providers/index.json
+++ b/docs/providers/index.json
@@ -85,6 +85,12 @@
       "cloud": true
     },
     {
+      "id": "providers/qvac",
+      "title": "QVAC",
+      "extension": true,
+      "cloud": false
+    },
+    {
       "id": "providers/qwen-code",
       "title": "Qwen Code CLI",
       "extension": true,

--- a/docs/providers/qvac.md
+++ b/docs/providers/qvac.md
@@ -15,9 +15,9 @@ keywords:
 
 # Using QVAC With Roo Code
 
-[QVAC](https://qvac.com) is an open-source runtime for local-first, peer-to-peer AI. It can expose your local models through an OpenAI-compatible HTTP server, letting you connect them to Roo Code using the **OpenAI Compatible** provider.
+[QVAC](https://qvac.tether.io) is an open-source runtime for local-first, peer-to-peer AI. It can expose your local models through an OpenAI-compatible HTTP server, letting you connect them to Roo Code using the **OpenAI Compatible** provider.
 
-**Website:** [https://qvac.com](https://qvac.com)
+**Website:** [https://qvac.tether.io](https://qvac.tether.io)
 
 ---
 

--- a/docs/providers/qvac.md
+++ b/docs/providers/qvac.md
@@ -77,7 +77,7 @@ keywords:
 *   **Use a capable, agent-tuned model.** Tool-calling quality is bounded by the model you run. Small models often fail to invoke tools reliably; a larger agent-tuned model such as `gpt-oss-20b` is a good local default.
 *   **Set the context window explicitly.** The QVAC LLM `ctx_size` default of `1024` is too small for Roo Code's prompts. Set it to something like `32768` in `qvac.config.json`.
 *   **Enable tools.** Roo Code uses native tool calling exclusively. Set `"tools": true` in the model config or the model will respond with text instead of tool calls.
-*   **Reasoning models.** For reasoning-tuned models such as Qwen3, set `"reasoning_budget": 0` in the model config unless you specifically want extended reasoning.
+*   **Reasoning models.** For reasoning-tuned models such as Qwen3.5, set `"reasoning_budget": 0` in the model config unless you specifically want extended reasoning.
 *   **Preload for a faster first response.** Setting `"preload": true` loads the model when the server starts, avoiding a cold start on your first request.
 *   **Resource requirements.** Running large language models locally is resource-intensive. Make sure your machine can handle the model and context size you choose.
 

--- a/docs/providers/qvac.md
+++ b/docs/providers/qvac.md
@@ -1,0 +1,91 @@
+---
+sidebar_label: QVAC
+description: Run local-first, peer-to-peer AI models with QVAC and connect them to Roo Code through its OpenAI-compatible server.
+keywords:
+  - QVAC
+  - local models
+  - Roo Code
+  - OpenAI compatible
+  - peer-to-peer AI
+  - local-first
+  - offline AI
+  - gpt-oss
+  - tool calling
+---
+
+# Using QVAC With Roo Code
+
+[QVAC](https://qvac.com) is an open-source runtime for local-first, peer-to-peer AI. It can expose your local models through an OpenAI-compatible HTTP server, letting you connect them to Roo Code using the **OpenAI Compatible** provider.
+
+**Website:** [https://qvac.com](https://qvac.com)
+
+---
+
+## Setting Up QVAC
+
+1.  **Install the QVAC CLI:**
+
+    ```bash
+    npm i -g @qvac/cli
+    ```
+
+2.  **Define a model alias:** Create a `qvac.config.json` that maps a serve alias to a model. The alias you choose here is the model id you will enter in Roo Code.
+
+    ```json
+    {
+      "serve": {
+        "models": {
+          "gpt-oss-20b": {
+            "model": "GPT_OSS_20B_INST_Q4_K_M",
+            "preload": true,
+            "config": {
+              "ctx_size": 32768,
+              "tools": true
+            }
+          }
+        }
+      }
+    }
+    ```
+
+    Two settings matter when using QVAC as a coding agent:
+    *   **`ctx_size`** defaults to `1024`, which is far too small for agent prompts. Set it explicitly (e.g. `32768`).
+    *   **`tools: true`** enables function/tool calling. Roo Code relies on native tool calling, so without this the model returns plain text instead of tool calls.
+
+3.  **Start the server:**
+
+    ```bash
+    qvac serve openai
+    ```
+
+    This starts an OpenAI-compatible REST API on port `11434` by default (use `--port` to change it). Your base URL is `http://127.0.0.1:11434/v1`.
+
+---
+
+## Configuration in Roo Code
+
+1.  **Open Roo Code Settings:** Click the gear icon (<Codicon name="gear" />) in the Roo Code panel.
+2.  **Select Provider:** Choose "OpenAI Compatible" from the "API Provider" dropdown.
+3.  **Enter Base URL:** Use `http://127.0.0.1:11434/v1` (or the port you set with `--port`).
+4.  **Enter API Key:** QVAC's server does not validate the key, but the field is required—enter any non-empty string (e.g. `qvac`).
+5.  **Enter Model ID:** Use the serve alias from your `qvac.config.json` (e.g. `gpt-oss-20b`).
+
+---
+
+## Tips and Notes
+
+*   **Use a capable, agent-tuned model.** Tool-calling quality is bounded by the model you run. Small models often fail to invoke tools reliably; a larger agent-tuned model such as `gpt-oss-20b` is a good local default.
+*   **Set the context window explicitly.** The QVAC LLM `ctx_size` default of `1024` is too small for Roo Code's prompts. Set it to something like `32768` in `qvac.config.json`.
+*   **Enable tools.** Roo Code uses native tool calling exclusively. Set `"tools": true` in the model config or the model will respond with text instead of tool calls.
+*   **Reasoning models.** For reasoning-tuned models such as Qwen3, set `"reasoning_budget": 0` in the model config unless you specifically want extended reasoning.
+*   **Preload for a faster first response.** Setting `"preload": true` loads the model when the server starts, avoiding a cold start on your first request.
+*   **Resource requirements.** Running large language models locally is resource-intensive. Make sure your machine can handle the model and context size you choose.
+
+---
+
+## Troubleshooting
+
+*   **"Model Not Found":** The model id in Roo Code must exactly match a serve alias defined in `qvac.config.json`.
+*   **Model replies with text instead of using tools:** Add `"tools": true` to the model's `config` in `qvac.config.json` and restart the server.
+*   **Context overflow or truncated prompts:** Increase `ctx_size` (the default `1024` is too small for agent prompts).
+*   **Connection errors:** Confirm `qvac serve openai` is running and that the Base URL and port match (`http://127.0.0.1:11434/v1` by default).


### PR DESCRIPTION
## What does this PR do?

Adds a provider setup page for **QVAC** and registers it in the providers index.

[QVAC](https://qvac.com) is an open-source runtime for local-first, peer-to-peer AI. It can expose your local models through an OpenAI-compatible HTTP server (`qvac serve openai`), so it connects to Roo Code through the existing **OpenAI Compatible** provider — no new provider code is required.

The page mirrors the format of the other local-provider pages (Ollama, LM Studio) and covers:

- Installing the QVAC CLI (`npm i -g @qvac/cli`).
- Defining a model alias in `qvac.config.json` and starting the server (default port `11434`).
- Configuring the OpenAI Compatible provider in Roo Code: Base URL `http://127.0.0.1:11434/v1`, any non-empty API key, and a model id equal to the serve alias.

It also documents the non-obvious settings needed for QVAC to work well as a coding agent:

- Set `ctx_size` explicitly — the default of `1024` is too small for agent prompts.
- Set `"tools": true` so the model emits native tool calls instead of plain text (Roo Code uses native tool calling exclusively).
- For reasoning-tuned models such as Qwen3, set `"reasoning_budget": 0`.
- Tool-calling quality is bounded by the model, so a larger agent-tuned model such as `gpt-oss-20b` is recommended for local use.

## Files changed

- `docs/providers/qvac.md` — new provider page.
- `docs/providers/index.json` — registers QVAC so it appears in the sidebar and the provider comparison table.

## How was it tested?

Validated `index.json`, and the new page follows the same structure and frontmatter as the existing local-provider pages. The page uses no images and only absolute, extensionless internal links per the repo's documentation rules.