### PR TITLE
docs: add Lynkr provider guide

### DIFF
--- a/docs/providers/index.json
+++ b/docs/providers/index.json
@@ -43,6 +43,12 @@
       "cloud": false
     },
     {
+      "id": "providers/lynkr",
+      "title": "Lynkr",
+      "extension": true,
+      "cloud": false
+    },
+    {
       "id": "providers/litellm",
       "title": "LiteLLM",
       "extension": true,

--- a/docs/providers/lynkr.md
+++ b/docs/providers/lynkr.md
@@ -1,0 +1,40 @@
+---
+sidebar_label: Lynkr
+description: Route Roo Code requests by complexity across local and cloud providers with Lynkr, a self-hosted OpenAI-compatible gateway with tool-output compression and semantic caching.
+keywords:
+  - lynkr
+  - roo code
+  - api provider
+  - openai compatible
+  - llm gateway
+  - complexity routing
+  - local deployment
+  - ollama
+  - cost management
+---
+
+# Using Lynkr With Roo Code
+
+Lynkr is a self-hosted, Apache-2.0 LLM gateway that exposes an OpenAI-compatible endpoint and routes each request by complexity: simple requests go to local models (Ollama, llama.cpp, LM Studio), complex ones to a cloud provider you configure (AWS Bedrock, Azure OpenAI, Databricks, OpenRouter, and others). It also strips unused tool schemas and compresses large JSON tool results, which reduces token usage on agentic sessions.
+
+**Website:** [https://github.com/Fast-Editor/Lynkr](https://github.com/Fast-Editor/Lynkr)
+
+## Setting Up Lynkr
+
+1.  **Install:** `npm install -g lynkr`
+2.  **Configure:** Run `lynkr init` — an interactive wizard where you choose tier models (SIMPLE/MEDIUM/COMPLEX/REASONING) across 13 supported providers and enter credentials for the ones you use.
+3.  **Start:** Run `lynkr start`. The gateway serves `http://localhost:8081`.
+
+## Configuration in Roo Code
+
+1.  **Open Roo Code Settings:** Click the gear icon in the Roo Code panel.
+2.  **Select Provider:** Choose "OpenAI Compatible" from the API Provider dropdown.
+3.  **Enter Base URL:** `http://localhost:8081/v1`
+4.  **Enter API Key:** Any non-empty value (provider authentication is handled inside Lynkr's own configuration).
+5.  **Set Model ID:** Any placeholder value — Lynkr's tier routing selects the actual model per request.
+
+## Tips and Notes
+
+*   **Local-first routing:** With local tiers configured, most simple requests never leave your machine; only complex, tool-heavy requests reach a paid provider.
+*   **Privacy:** Lynkr is fully self-hosted — requests go only to the providers you configured, with no third-party gateway in between.
+*   **Tuning:** See [Lynkr's routing documentation](https://github.com/Fast-Editor/Lynkr/blob/main/documentation/routing.md) for tier configuration and complexity-threshold modes.


### PR DESCRIPTION
Adds a provider page for Lynkr, a self-hosted Apache-2.0 gateway usable with Roo Code via the OpenAI Compatible provider, plus its providers/index.json entry (alphabetical placement).

Lynkr routes each request by complexity — simple requests to local models (Ollama/llama.cpp/LM Studio), complex ones to a configured cloud provider — and reduces token usage via tool-schema stripping and JSON tool-result compression. Repo: https://github.com/Fast-Editor/Lynkr

Page follows the structure of the existing gateway pages (LiteLLM/Requesty). Happy to adjust to conventions.