### PR TITLE
docs: add DaoXE OpenAI-compatible provider guide

### DIFF
--- a/docs/providers/daoxe.md
+++ b/docs/providers/daoxe.md
@@ -1,0 +1,65 @@
+---
+sidebar_label: DaoXE
+description: Configure DaoXE in Roo Code as a multi-model multi-protocol AI API gateway via the OpenAI Compatible provider.
+keywords:
+  - DaoXE
+  - Roo Code
+  - OpenAI compatible
+  - multi-model
+  - multi-protocol
+  - API gateway
+  - custom endpoint
+---
+
+# Using DaoXE With Roo Code
+
+[DaoXE](https://daoxe.com) is a multi-model multi-protocol AI API gateway for developers.
+In Roo Code, connect through the **OpenAI Compatible** provider using:
+
+- **Base URL:** `https://daoxe.com/v1`
+- **API Key:** your DaoXE account key
+- **Model ID:** an exact model ID currently available to your account
+
+DaoXE supports OpenAI Chat Completions, OpenAI Responses, Anthropic Messages, and image-compatible endpoints. Roo Code uses the OpenAI Chat Completions path below.
+
+> DaoXE is **not available in mainland China**.
+
+**Website:** [https://daoxe.com](https://daoxe.com)  
+**Examples:** [DaoXE-AI](https://github.com/seven7763/DaoXE-AI)
+
+---
+
+## Getting an API Key
+
+1. Create or sign in to your [DaoXE account](https://daoxe.com).
+2. Create an API key in the dashboard.
+3. Copy the key. Do not commit it to source control.
+
+---
+
+## Available Models
+
+DaoXE model availability is account-scoped. Prefer the models returned for your key over a static list.
+
+- Public catalog/pricing: [https://daoxe.com/pricing](https://daoxe.com/pricing)
+- Authenticated discovery endpoint used by many clients: `GET https://daoxe.com/v1/models`
+
+---
+
+## Configuration in Roo Code
+
+1. Open Roo Code Settings (gear icon).
+2. Set **API Provider** to **OpenAI Compatible**.
+3. Set **Base URL** to `https://daoxe.com/v1`.
+4. Paste your DaoXE API key into **API Key**.
+5. Enter an exact currently available DaoXE model ID in **Model**.
+
+For tool use / agent features, choose a model that supports OpenAI-compatible tool/function calling.
+
+---
+
+## Tips
+
+- Do not invent or hardcode model IDs from old screenshots; re-copy from your account.
+- If you get model-not-found errors, refresh the catalog for your key and update the Model field.
+- Public smoke/compare examples: [DaoXE-AI](https://github.com/seven7763/DaoXE-AI).

--- a/docs/providers/index.json
+++ b/docs/providers/index.json
@@ -25,6 +25,12 @@
       "cloud": false
     },
     {
+      "id": "providers/daoxe",
+      "title": "DaoXE",
+      "extension": true,
+      "cloud": false
+    },
+    {
       "id": "providers/fireworks",
       "title": "Fireworks AI",
       "extension": true,

--- a/docs/providers/openai-compatible.md
+++ b/docs/providers/openai-compatible.md
@@ -18,6 +18,7 @@ Roo Code supports a wide range of AI model providers that offer APIs compatible 
 
 *   **Local models** running through tools like Ollama and LM Studio (covered in separate sections).
 *   **Cloud providers** like Perplexity, Together AI, Anyscale, and others.
+*   **Multi-model gateways** such as [DaoXE](/providers/daoxe) (`https://daoxe.com/v1`).
 *   **Any other provider** offering an OpenAI-compatible API endpoint.
 
 This document focuses on setting up providers *other than* the official OpenAI API (which has its own [dedicated configuration page](/providers/openai)).
@@ -45,6 +46,18 @@ You'll find these settings in the Roo Code settings panel (click the <Codicon na
     - Computer Use
     - Input Price
     - Output Price
+
+
+## Example: DaoXE
+
+[DaoXE](https://daoxe.com) is a multi-model multi-protocol AI API gateway.
+
+1. Select **OpenAI Compatible** as the API Provider.
+2. Set **Base URL** to `https://daoxe.com/v1`.
+3. Paste your DaoXE API key.
+4. Enter an exact model ID currently available to your account.
+
+DaoXE is not available in mainland China. See the dedicated [DaoXE guide](/providers/daoxe) for more detail.
 
 ---
 


### PR DESCRIPTION
## Summary
- Add a dedicated **DaoXE** provider page under `docs/providers/`.
- Cross-link from the OpenAI Compatible provider guide.
- Register DaoXE in `docs/providers/index.json`.
- Document Base URL `https://daoxe.com/v1`, account-scoped model IDs, multi-protocol scope, and mainland-China unavailability.
- Link public examples: https://github.com/seven7763/DaoXE-AI

## Disclosure
I am affiliated with DaoXE.

## Test plan
- [ ] Docs page renders
- [ ] Provider index/table includes DaoXE
- [ ] Links resolve